### PR TITLE
feat: add end-to-end local inference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ Your terminal
 
 ## First run
 
-Start `otis` and select **Set up Otis**. Setup opens Fireworks' official key page, hides key input, and walks through
-model selection before starting a session.
+Start `otis` and select **Set up Otis**, then choose where inference runs:
+
+- **Local inference** downloads and runs a model on your machine. For a good experience, use Apple silicon with at
+  least 24 GB of unified memory, or Linux with at least 24 GB of RAM. A Vulkan-capable GPU improves speed; 16 GB or
+  more of VRAM is recommended. Each model uses 12–19 GB of disk space.
+- **Hosted inference** runs remote models using your own API key and has no local hardware requirements. You can
+  configure hosted inference later in Settings.
+
+Choosing hosted inference opens the current provider's key page and continues with a verified tool-capable model.
+Choosing local opens the hardware-aware local model catalog without requiring a hosted inference API key.
 
 | Provider | Why Otis needs it | Get a key |
 | --- | --- | --- |
@@ -79,15 +87,21 @@ export FIREWORKS_API_KEY=fw_your_key
 otis
 ```
 
-After setup, `/model` lists local llama.cpp models above Fireworks. Selecting a runnable local model downloads
-`llama-server` and the GGUF into Otis' local data directory and serves it on `127.0.0.1`. Download progress and
-Downloaded appear next to the model name in that list. Otis gives llama.cpp a hardware-scaled memory budget that keeps
-system headroom on unified-memory and CPU machines and per-device headroom on discrete GPUs. llama.cpp fits context and
-GPU offload inside that budget at startup, up to the checkpoint's native window, and Otis uses the context the server
-actually loaded. Unloaded rows say `Up to`; the active local model says `loaded` with its runtime context. Models that
-cannot fit even 8K inside the budget stay visible and greyed out.
-When at least one GGUF is present, `/delete-model` appears and opens a downloaded-model submenu. Deleting the active or
-final local model stops Otis' `llama-server`; deleting an inactive model leaves the current server untouched.
+After setup, `/model` lists local llama.cpp models above hosted models. Local inference is supported on macOS and Linux
+on arm64 and x64; unsupported platforms show local models as unavailable before a download starts. Selecting a runnable
+model downloads Otis' pinned, checksum-verified `llama-server` runtime and a revision-pinned, checksum-verified GGUF
+into the local data directory, then serves it on `127.0.0.1`. Interrupted GGUF downloads resume from a partial file;
+the complete result must still pass its pinned size and checksum. Download progress and `Downloaded` appear next to
+the model name in the picker.
+
+Otis checks whether the model can fit in system memory, including a conservative runtime reserve. On Linux,
+llama.cpp uses Vulkan when a render device is present and can split the model between GPU memory and system RAM, so a
+smaller GPU does not make a model unavailable. CPU-only inference remains available but is slower. llama.cpp's fitter
+chooses the actual context and GPU offload at startup; Otis reports the context the server loaded. Unloaded rows show an
+`Est.` context, while the active local model shows `loaded`. Models that cannot fit even 8K stay visible and greyed out.
+
+When at least one GGUF is present, Settings includes a local-model deletion menu. Deleting the active or final local
+model stops Otis' `llama-server`; deleting an inactive model leaves the current server untouched.
 
 ## Commands and controls
 
@@ -135,11 +149,10 @@ Run `otis exec --help` for the full option list. Headless mode is non-interactiv
 | `/home` | Return to the home screen |
 | `/new` | Start a new session |
 | `/history` | Browse, open, or delete local sessions |
-| `/model` | Choose a local llama.cpp model or a tool-capable Fireworks model |
-| `/delete-model` | Delete a local model from a slash-menu submenu (shown only when one is downloaded) |
+| `/model` | Choose a local llama.cpp model or a tool-capable hosted model |
+| `/settings` | Configure hosted inference, delete downloaded local models, or toggle debug mode |
 | `/fast` | Toggle Fast serving when the current model allows it |
 | `/compact [instructions]` | Summarize older conversation and free context |
-| `/debug` | Toggle diagnostic transcript entries |
 | `/thinking` | Toggle model-provided thinking traces |
 | `/exit` | Exit Otis |
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -24,8 +24,8 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 ## llama.cpp
 
-Otis downloads official [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server` binaries from GitHub Releases
-for local inference. llama.cpp is distributed under the MIT License:
+Otis downloads official [llama.cpp](https://github.com/ggml-org/llama.cpp) `llama-server` binaries from the pinned
+`b10622` GitHub Release for local inference. llama.cpp is distributed under the MIT License:
 
 MIT License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,30 +85,48 @@ come from the model author when they publish GGUF, otherwise from ggml-org or a 
 weights. Each row reports a fitted context and memory estimate; models that cannot fit even 8K context stay visible and
 unselectable. Context is the largest window that still fits, up to the checkpoint's native length. Memory math uses
 each checkpoint's real KV groups (full-attention layers vs sliding-window layers), not a uniform transformer cache.
-The fit policy reserves 15% of Apple unified memory (at least 3 GiB), 10% of CPU-only system memory (at least 2 GiB),
-and 1 GiB per discrete GPU. On NVIDIA Linux, the picker queries both total and currently free VRAM. Capacity after
-headroom controls hard availability, while currently free VRAM after the same headroom silently adjusts the
-recommendation when another GPU workload is active.
+Hard availability is based on host memory because llama.cpp can split a model between a discrete GPU and system RAM.
+The preflight estimate reserves 15% of Apple unified memory (at least 3 GiB), 10% of other system memory (at least
+2 GiB), and another 1.5 GiB for runtime buffers. It never requires the complete model to fit in VRAM. On Linux,
+`nvidia-smi` detects NVIDIA devices and DRM render nodes detect any other Vulkan-capable GPU, including AMD and Intel.
+If no render device is present, Otis uses the CPU build.
+
 Picker and settings rows are a provider-tagged catalog: Fireworks entries may include a Fast serving path; local entries
-carry a fitted context and never a `fastId`. Local rows not currently serving label that context `Up to`; the active
+carry a fitted context and never a `fastId`. Local rows not currently serving label that context `Est.`; the active
 local row receives the context returned by llama.cpp and labels it `loaded`.
 
-Selecting a runnable local model downloads the latest llama.cpp `b*` GitHub prerelease with real assets (Metal on
-Apple Silicon, Vulkan on Linux NVIDIA, otherwise CPU) and the selected GGUF into the platform local-data directory.
+Selecting a runnable local model downloads Otis' pinned llama.cpp `b10622` GitHub release (Metal on Apple Silicon,
+Vulkan on Linux with a render device, otherwise CPU) and the selected GGUF into the platform local-data directory.
+macOS and Linux on arm64 and x64 are supported; other targets are disabled before selection. Runtime asset sizes and
+SHA-256 digests are pinned with the release, and the archive is verified while streaming to disk. Updating the runtime
+requires an explicit Otis source change. Existing compatible manifest-v1 and pre-manifest bundles remain usable for
+released installations; newly installed bundles record the artifact digest, and obsolete `b*` directories are removed
+after the pinned runtime is available.
+
+Each GGUF URL contains an immutable Hugging Face revision. Otis verifies the pinned byte count and Git LFS SHA-256,
+publishes the completed file atomically, and records a private sidecar manifest so a verified cache does not need to be
+hashed on every launch. Interrupted downloads retain one stable partial file and resume with a validated byte-range
+request. A per-model lock serializes concurrent downloads and deletion across Otis processes.
+
 Download percent and a loading state appear next to the model name in the `/model` picker. Local rows already on disk
-show Downloaded next to the name. Otis then starts `llama-server` on `127.0.0.1` with `--jinja` and without llama.cpp
+show `Downloaded` next to the name. Otis then starts `llama-server` on `127.0.0.1` with `--jinja` and without llama.cpp
 `--tools`. Chat then uses the same OpenAI-compatible SSE path as Fireworks, without Fireworks-only `service_tier` or
 `reasoning_effort` fields. Otis tools remain in the local runtime. `OTIS_LLAMA_SERVER` overrides the bundled binary.
-llama.cpp's native fitter is authoritative at startup. Otis passes the same per-device headroom used by preflight as
-`--fit-target`, reads `/props`, and persists the context actually loaded. Otis also removes inherited `LLAMA_ARG_*`
+llama.cpp's native fitter is authoritative at startup. Otis passes 1 GiB of fit headroom for a discrete GPU, or the
+system-memory headroom for unified-memory and CPU backends, then reads `/props` and persists the context actually
+loaded. Layers that do not fit in discrete GPU memory remain in system RAM. Otis also removes inherited `LLAMA_ARG_*`
 variables from the child environment so a separate llama.cpp configuration cannot silently alter its managed server.
-When cached GGUFs exist, interactive mode exposes `/delete-model` with a second-level slash-menu list. It only targets files in Otis' model cache, stops
-Otis' server before deleting the active or final model, and clears an active selection before offering the model picker
-again. Inactive model deletion does not interrupt a different active local model.
+When cached GGUFs exist, Settings exposes a second-level local-model deletion list. It only targets files in Otis'
+model cache, stops Otis' server before deleting the active or final model, and clears an active selection before
+offering the model picker again. Inactive model deletion does not interrupt a different active local model.
 Interactive `/exit`, Ctrl+C, and SIGINT/SIGTERM wait for `llama-server` to stop before destroying the OpenTUI renderer.
 Headless `otis exec` awaits that stop in `finally`.
 
-First-run setup still requires a Fireworks key. Headless `otis exec --model <local-id>` does not.
+First-run setup offers local and hosted inference before requesting credentials. The local route opens the
+hardware-filtered catalog without a hosted inference API key; the hosted route requests the current provider's key and
+selects a verified tool-capable default model. Headless `otis exec --model <local-id>` also does not require a hosted
+inference API key. `/settings` can validate and save that key later without replacing the selected local model, opens
+cached-model deletion when a GGUF is present, and owns the ephemeral debug-mode toggle.
 
 ## Parallel boundary
 

--- a/src/cli/chat-ui.ts
+++ b/src/cli/chat-ui.ts
@@ -15,7 +15,7 @@ import {
 } from "./ui/format.js"
 import { HomeStats } from "./ui/home-stats.js"
 import { InputController } from "./ui/input-controller.js"
-import { createUILayout, setTopBarSideMinWidth, themeRootsFrom } from "./ui/layout.js"
+import { createUILayout, setTopBarSideMinWidth, setWelcomePanelExpanded, themeRootsFrom } from "./ui/layout.js"
 import { ModelPicker } from "./ui/model-picker.js"
 import { OverlayHost } from "./ui/overlays.js"
 import { createScrollbarOptions } from "./ui/panels.js"
@@ -58,6 +58,10 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
     sessionPanel,
     sessionRowsBox,
     setupButtonBox,
+    setupChoiceBox,
+    setupChoiceMessage,
+    setupHostedCard,
+    setupLocalCard,
     setupContinueButton,
     setupForm,
     setupInput,
@@ -112,10 +116,15 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
   const inputController = new InputController({
     renderer,
     configured: options.configured !== false,
+    localInferenceUnavailableReason: options.localInferenceUnavailableReason,
     input,
     inputArea,
     inputBox,
     setupButtonBox,
+    setupChoiceBox,
+    setupChoiceMessage,
+    setupHostedCard,
+    setupLocalCard,
     setupContinueButton,
     setupForm,
     setupInput,
@@ -126,7 +135,9 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
     setupStatusBox,
     welcomeQuit,
     onBeforePrimaryInput: () => overlays.hideCommandMenu(),
+    onModeChange: (mode) => setWelcomePanelExpanded(welcomePanel, mode === "setupChoice"),
     onSetup: options.onSetup,
+    onSetupInferenceChoice: options.onSetupInferenceChoice,
     onSetupSubmit: options.onSetupSubmit,
   })
   overlays = new OverlayHost({
@@ -168,7 +179,7 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
   input.onContentChange = () => {
     if (inputController.mode !== "chat") return
     const value = input.plainText
-    if (overlays.themeMenuOpen && value === "") {
+    if (overlays.submenuOpen && value === "") {
       options.onInputChange?.(value)
       return
     }
@@ -312,6 +323,13 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
     overlays.hideCommandMenu()
   }
 
+  function showSlashCommandMenu() {
+    input.setText("/")
+    overlays.updateCommandMenu("/")
+    options.onInputChange?.("/")
+    inputController.focus()
+  }
+
   function setImageAttachmentCount(count: number) {
     setText(imageAttachments, imageAttachmentLabel(count))
     const mounted = inputBox.getChildren().some((child) => child.id === imageAttachments.id)
@@ -438,11 +456,12 @@ export function createChatUI(renderer: Renderer, options: ChatUIOptions): ChatUI
     setThinkingVisible,
     showStats,
     showTransientHint: (content) => status.showTransientHint(content),
-    showCommandSubmenu: (items) => overlays.showCommandSubmenu(items),
+    showCommandSubmenu: (items, submenuOptions) => overlays.showCommandSubmenu(items, submenuOptions),
+    showSlashCommandMenu,
     showModelPicker: (items) => overlays.showModelPicker(items),
-    showSetupError: (message) => inputController.showSetupError(message),
-    showSetupButton: () => inputController.showSetupButton(),
-    showSetupInput: (message) => inputController.showSetup(message),
+    showSetupError: (message, cancelTarget) => inputController.showSetupError(message, cancelTarget),
+    showSetupInferenceChoice: (message) => inputController.showSetupInferenceChoice(message),
+    showSetupInput: (message, cancelTarget) => inputController.showSetup(message, cancelTarget),
     showSetupStatus: (message) => inputController.showSetupStatus(message),
     showPermissionPrompt,
     showSessionPicker: (items) => overlays.showSessionPicker(items),

--- a/src/cli/headless-cli.ts
+++ b/src/cli/headless-cli.ts
@@ -10,7 +10,12 @@ import { findLocalModel, isLocalModelId } from "../inference/local-catalog.js"
 import { LlamaCppClient } from "../inference/local-client.js"
 import { fitLocalModel } from "../inference/local-fit.js"
 import { createUserMessage, imageAttachmentsFromMessages, messagesContainImages } from "../inference/messages.js"
-import { findFireworksModel, fireworksServingModel, useFastServingPath } from "../inference/serving-path.js"
+import {
+  baseFireworksModelId,
+  findFireworksModel,
+  fireworksServingModel,
+  useFastServingPath,
+} from "../inference/serving-path.js"
 import { skillAdvertisementChars } from "../inference/system-prompt.js"
 import type { ChatMessage, InferenceClient } from "../inference/types.js"
 import { loadLocalSettings, saveSelectedModel } from "../local/settings.js"
@@ -113,7 +118,7 @@ export async function runHeadlessCommand(argv: string[], options: HeadlessComman
       if (!settings.fireworksApiKey) throw new Error("Fireworks API key is not configured.")
       if (parsed.model || (images.length > 0 && modelSupportsImageInput === undefined)) {
         const resolved = await resolveFireworksServing(settings.fireworksApiKey, model, {
-          fastMode: parsed.model ? undefined : settings.fastMode,
+          fast: parsed.model ? undefined : settings.fastServingModels?.includes(baseFireworksModelId(model)),
           signal: controller.signal,
         })
         model = resolved.serving.id
@@ -143,7 +148,7 @@ export async function runHeadlessCommand(argv: string[], options: HeadlessComman
     const sessionContainsImages = session ? messagesContainImages(session.replayMessages()) : false
     if (sessionContainsImages && modelSupportsImageInput === undefined && settings.fireworksApiKey) {
       const resolved = await resolveFireworksServing(settings.fireworksApiKey, model, {
-        fastMode: parsed.model ? undefined : settings.fastMode,
+        fast: parsed.model ? undefined : settings.fastServingModels?.includes(baseFireworksModelId(model)),
         signal: controller.signal,
       })
       model = resolved.serving.id
@@ -416,14 +421,14 @@ function interruptionMessage(signal: AbortSignal) {
 async function resolveFireworksServing(
   apiKey: string,
   modelId: string,
-  options: { fastMode?: boolean; signal: AbortSignal },
+  options: { fast?: boolean; signal: AbortSignal },
 ) {
   const models = await listToolCapableModels(apiKey, { signal: options.signal })
   const selected = findFireworksModel(models, modelId)
   if (!selected) throw new Error(`Model is not a tool-capable Fireworks serverless model: ${modelId}`)
   return {
     selected,
-    serving: fireworksServingModel(selected, useFastServingPath(modelId, options.fastMode)),
+    serving: fireworksServingModel(selected, useFastServingPath(modelId, options.fast)),
   }
 }
 

--- a/src/cli/image-flow.ts
+++ b/src/cli/image-flow.ts
@@ -83,7 +83,7 @@ export class ImageFlow {
       return
     }
     const apiKey = this.options.apiKey()
-    if (!apiKey) throw new Error("Select a Fireworks model first.")
+    if (!apiKey) throw new Error("Select a hosted model first.")
     if (this.#supportsImageInput === false) {
       throw new Error(`Selected model does not support image input: ${modelId}`)
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,8 +22,10 @@ try {
     case "version":
       console.log(`otis ${version}`)
       break
-    default:
-      await (await import("./interactive-cli.js")).startInteractiveCli()
+    default: {
+      const { InteractiveApp } = await import("./interactive-app.js")
+      await InteractiveApp.start()
+    }
   }
 } catch (error) {
   console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)

--- a/src/cli/interactive-app.ts
+++ b/src/cli/interactive-app.ts
@@ -4,6 +4,7 @@ import { loadProjectContext } from "../core/context.js"
 import { FireworksClient } from "../inference/client.js"
 import { deleteLocalGguf, listDownloadedLocalModels } from "../inference/gguf-cache.js"
 import { detectHardware, type HardwareProbe } from "../inference/hardware.js"
+import { supportsLlamaCppTarget, unsupportedLlamaCppTargetMessage } from "../inference/llama-binary.js"
 import { LlamaCppRuntime, type LocalServingEndpoint } from "../inference/llama-runtime.js"
 import {
   catalogModelFromSpec,
@@ -14,7 +15,8 @@ import {
 import { LlamaCppClient } from "../inference/local-client.js"
 import { fitLocalModel, formatMemoryLabel, type LocalModelFit } from "../inference/local-fit.js"
 import { createUserMessage, summarizeUserMessage, userMessageContentChars } from "../inference/messages.js"
-import { isFastFireworksModel } from "../inference/serving-path.js"
+import type { ModelPickerStatus } from "../inference/picker-catalog.js"
+import { baseFireworksModelId, isFastFireworksModel } from "../inference/serving-path.js"
 import { skillAdvertisementChars } from "../inference/system-prompt.js"
 import { type CatalogModel, type ContextFile, type InferenceClient, isLocalCatalogModel } from "../inference/types.js"
 import {
@@ -93,15 +95,17 @@ export class InteractiveApp {
   #permissionRules: PermissionRule[] = []
   #selectedTheme: ThemeName = "default"
   #thinkingVisible = false
-  #fastMode = false
+  #fastServingModels = new Set<string>()
   #fastAvailable = false
   #downloadedModelsAvailable = false
   #activeTurn: AbortController | undefined
   #updateCheckController: AbortController | undefined
   #startupModelController: AbortController | undefined
   #modelApplyId = 0
-  #localLoadStatus: { modelId: string; label: string } | undefined
-  #activeLocalModel: { spec: LocalModelSpec; fit: LocalModelFit; hardware: HardwareProbe } | undefined
+  #localLoadStatus: { modelId: string; status: ModelPickerStatus } | undefined
+  #activeLocalModel:
+    | { spec: LocalModelSpec; fit: LocalModelFit; hardware: HardwareProbe; contextLength: number }
+    | undefined
 
   static async start() {
     const app = new InteractiveApp()
@@ -110,10 +114,13 @@ export class InteractiveApp {
 
   async #boot() {
     const settings = await loadLocalSettings()
+    const localInferenceUnavailableReason = supportsLlamaCppTarget(process)
+      ? undefined
+      : unsupportedLlamaCppTargetMessage(process)
     selectTheme(settings.theme)
     this.#selectedTheme = settings.theme ?? "default"
     this.#thinkingVisible = settings.thinkingVisible ?? false
-    this.#fastMode = settings.fastMode ?? false
+    this.#fastServingModels = new Set(settings.fastServingModels ?? [])
     this.#fastAvailable = Boolean(settings.modelFastId) || isFastFireworksModel(settings.model ?? "")
     this.#downloadedModelsAvailable = (await listDownloadedLocalModels()).length > 0
     this.#fireworksApiKey = settings.fireworksApiKey
@@ -146,9 +153,9 @@ export class InteractiveApp {
 
     this.#ui = createChatUI(this.#renderer, {
       configured: this.#configured,
+      localInferenceUnavailableReason,
       commands: slashCommands({
         fast: this.#fastAvailable,
-        downloadedModels: this.#downloadedModelsAvailable,
       }),
       contextLabel: formatContextUsage(
         contextUsage(
@@ -175,6 +182,7 @@ export class InteractiveApp {
       },
       onQuit: () => this.#quit(),
       onSetup: () => this.#setupFlow.begin(),
+      onSetupInferenceChoice: (choice) => this.#setupFlow.selectInference(choice),
       onSetupSubmit: (apiKey) => {
         void this.#setupFlow.submitCredential(apiKey)
       },
@@ -209,12 +217,19 @@ export class InteractiveApp {
     })
     this.#setupFlow = new SetupFlow({
       settings,
+      localInferenceUnavailableReason,
       isBusy: () => this.#busy,
       setBusy: (value) => {
         this.#busy = value
       },
       onCredentialsChanged: (credentials) => {
         this.#fireworksApiKey = credentials.fireworksApiKey
+        if (credentials.fireworksApiKey && this.#selectedModelId && !isLocalModelId(this.#selectedModelId)) {
+          this.#client = new FireworksClient({
+            apiKey: credentials.fireworksApiKey,
+            model: this.#selectedModelId,
+          })
+        }
         this.#ui.showStats()
         void this.#refreshLocalStats()
       },
@@ -223,16 +238,18 @@ export class InteractiveApp {
       localLoadStatus: () => this.#localLoadStatus,
       loadedLocalModel: () =>
         this.#activeLocalModel
-          ? { model: this.#activeLocalModel.spec.id, contextLength: this.#activeLocalModel.fit.contextLength }
+          ? { model: this.#activeLocalModel.spec.id, contextLength: this.#activeLocalModel.contextLength }
           : undefined,
       onConfigured: (fireworksKey) => {
         if (fireworksKey) this.#fireworksApiKey = fireworksKey
         this.#configured = true
         void this.#refreshLocalStats()
       },
-      fastMode: () => this.#fastMode,
-      onFastModeChanged: (fast) => {
-        this.#fastMode = fast
+      fastEnabled: (modelId) => this.#fastServingModels.has(baseFireworksModelId(modelId)),
+      onFastChanged: (modelId, fast) => {
+        const baseModelId = baseFireworksModelId(modelId)
+        if (fast) this.#fastServingModels.add(baseModelId)
+        else this.#fastServingModels.delete(baseModelId)
       },
       ui: this.#ui,
     })
@@ -261,7 +278,6 @@ export class InteractiveApp {
           startupController.signal.throwIfAborted()
           prepared.commit()
           this.#configured = true
-          this.#ui.setConfigured()
         } catch (error) {
           if (prepared) await prepared.rollback({ restorePrevious: false })
           if (startupController.signal.aborted || this.#exiting) return
@@ -350,10 +366,18 @@ export class InteractiveApp {
         await this.#setupFlow.openModelPicker(this.#fireworksApiKey, this.#selectedModelId, true)
         return
       }
-      case "delete-model": {
+      case "settings": {
         this.#ui.clearInput()
-        if (command.modelId) this.#startLocalModelDeletion(command.modelId)
-        else await this.#openLocalModelDeleteMenu()
+        if (command.setting === "hosted") {
+          this.#setupFlow.configureHostedInference()
+        } else if (command.setting === "debug") {
+          this.#toggleDebugMode()
+        } else if (command.setting === "delete-model") {
+          if (command.modelId) this.#startLocalModelDeletion(command.modelId)
+          else await this.#openLocalModelDeleteMenu()
+        } else {
+          this.#openSettingsMenu()
+        }
         return
       }
       case "fast":
@@ -372,16 +396,6 @@ export class InteractiveApp {
         this.#ui.clearInput()
         this.#ui.showHomeLayout()
         void this.#refreshLocalStats()
-        this.#ui.focusInput()
-        return
-      case "debug":
-        this.#debug = !this.#debug
-        this.#ui.showChatLayout()
-        this.#transcript.addUserMessage("/debug")
-        this.#transcript.addAssistantMessage(`Debug mode ${this.#debug ? "enabled" : "disabled"}.`)
-        this.#ui.clearInput()
-        this.#updateContextIndicator()
-        this.#ui.renderTranscript(this.#transcript.entries, { scrollToBottom: true })
         this.#ui.focusInput()
         return
       case "thinking":
@@ -639,13 +653,46 @@ export class InteractiveApp {
     this.#showLocalModelDeleteMenu(models)
   }
 
+  #openSettingsMenu() {
+    const items = [
+      {
+        name: "Hosted inference",
+        description: this.#fireworksApiKey ? "Replace API key" : "Add API key",
+        submission: "/settings hosted",
+      },
+      ...(this.#downloadedModelsAvailable
+        ? [
+            {
+              name: "Delete local model",
+              description: "Choose a downloaded model",
+              submission: "/settings delete-model",
+            },
+          ]
+        : []),
+      {
+        name: "Debug mode",
+        description: this.#debug ? "On" : "Off",
+        submission: "/settings debug",
+      },
+    ]
+    this.#ui.showCommandSubmenu(items, { onBack: () => this.#ui.showSlashCommandMenu() })
+    this.#ui.focusInput()
+  }
+
+  #toggleDebugMode() {
+    this.#debug = !this.#debug
+    this.#ui.showTransientHint(` Debug mode ${this.#debug ? "on" : "off"} `)
+    this.#ui.focusInput()
+  }
+
   #showLocalModelDeleteMenu(models: readonly LocalModelSpec[]) {
     this.#ui.showCommandSubmenu(
       models.map((model) => ({
         name: model.displayName,
         description: `${model.id === this.#selectedModelId ? "Active · " : ""}${model.quant} · ${formatMemoryLabel(model.weightBytes)}`,
-        submission: `/delete-model ${model.id}`,
+        submission: `/settings delete-model ${model.id}`,
       })),
+      { onBack: () => this.#openSettingsMenu() },
     )
     this.#ui.focusInput()
   }
@@ -675,14 +722,14 @@ export class InteractiveApp {
     let active = false
     let settingsCleared = false
     let previousActive = this.#activeLocalModel
-    let previousModel = catalogModelFromSpec(spec, previousActive?.fit.contextLength)
+    let previousModel = catalogModelFromSpec(spec, previousActive?.contextLength)
     let remaining: LocalModelSpec[] = []
 
     try {
       await this.#setupFlow.cancelModelSelection()
       active = this.#selectedModelId === spec.id
       previousActive = this.#activeLocalModel
-      previousModel = catalogModelFromSpec(spec, previousActive?.fit.contextLength)
+      previousModel = catalogModelFromSpec(spec, previousActive?.contextLength)
       const downloaded = await listDownloadedLocalModels()
       const deletingLast = downloaded.length === 1 && downloaded[0]?.id === spec.id
 
@@ -768,16 +815,16 @@ export class InteractiveApp {
           signal,
           onProgress: (progress) => {
             if (applyId !== this.#modelApplyId || signal.aborted || this.#exiting) return
-            const label = formatLocalLoadStatus(progress)
-            this.#localLoadStatus = { modelId: spec.id, label }
-            this.#ui.setModelPickerStatus(spec.id, label)
+            const status: ModelPickerStatus = { label: formatLocalLoadStatus(progress), kind: "progress" }
+            this.#localLoadStatus = { modelId: spec.id, status }
+            this.#ui.setModelPickerStatus(spec.id, status)
           },
         })
         signal.throwIfAborted()
         this.#setDownloadedModelsAvailable(true)
       } catch (error) {
         this.#clearLocalLoadStatus(spec.id)
-        await this.#refreshDownloadedModelCommands()
+        await this.#refreshDownloadedModelAvailability()
         if (!signal.aborted && !this.#exiting) await this.#restoreLocalRuntime(previousLocal, error, signal)
         throw error
       }
@@ -790,8 +837,9 @@ export class InteractiveApp {
           finalized = true
           this.#activeLocalModel = {
             spec,
-            fit: { ...fit, contextLength: serving.contextLength },
+            fit,
             hardware,
+            contextLength: serving.contextLength,
           }
           this.#activateModel(
             activeModel,
@@ -855,7 +903,7 @@ export class InteractiveApp {
   }
 
   async #restoreLocalRuntime(
-    previous: { spec: LocalModelSpec; fit: LocalModelFit; hardware: HardwareProbe } | undefined,
+    previous: { spec: LocalModelSpec; fit: LocalModelFit; hardware: HardwareProbe; contextLength: number } | undefined,
     originalError?: unknown,
     signal?: AbortSignal,
   ) {
@@ -866,7 +914,13 @@ export class InteractiveApp {
       }
       const serving = await this.#llama.ensureServing(previous.spec, previous.fit, previous.hardware, { signal })
       signal?.throwIfAborted()
+      previous.contextLength = serving.contextLength
+      this.#activeLocalModel = previous
       this.#client = new LlamaCppClient({ model: previous.spec.id, inferenceURL: serving.inferenceURL })
+      if (this.#selectedModelId === previous.spec.id) {
+        this.#autoCompactAtTokens = autoCompactThreshold(serving.contextLength)
+        if (!this.#exiting) this.#updateContextIndicator()
+      }
     } catch (restoreError) {
       if (originalError === undefined) throw restoreError
       throw new AggregateError(
@@ -888,18 +942,15 @@ export class InteractiveApp {
 
   #setDownloadedModelsAvailable(available: boolean) {
     this.#downloadedModelsAvailable = available
-    if (!this.#exiting) this.#refreshCommands()
   }
 
-  async #refreshDownloadedModelCommands() {
+  async #refreshDownloadedModelAvailability() {
     const available = (await listDownloadedLocalModels()).length > 0
     if (!this.#exiting) this.#setDownloadedModelsAvailable(available)
   }
 
   #refreshCommands() {
-    this.#ui.setCommands(
-      slashCommands({ fast: this.#fastAvailable, downloadedModels: this.#downloadedModelsAvailable }),
-    )
+    this.#ui.setCommands(slashCommands({ fast: this.#fastAvailable }))
   }
 
   #updateContextIndicator(pendingInput = "") {

--- a/src/cli/interactive-cli.ts
+++ b/src/cli/interactive-cli.ts
@@ -1,5 +1,0 @@
-import { InteractiveApp } from "./interactive-app.js"
-
-export async function startInteractiveCli() {
-  await InteractiveApp.start()
-}

--- a/src/cli/setup-flow.ts
+++ b/src/cli/setup-flow.ts
@@ -5,17 +5,25 @@ import {
   isSelectablePickerItem,
   listModelPickerItems,
   type ModelPickerItem,
+  type ModelPickerStatus,
   toLocalCatalogModel,
 } from "../inference/picker-catalog.js"
 import { findFireworksModel, fireworksServingModel, isFastFireworksModel } from "../inference/serving-path.js"
 import type { CatalogModel, FireworksModel, LocalCatalogModel } from "../inference/types.js"
-import { type LocalSettings, saveFastMode, saveFireworksSetup, saveSelectedModel } from "../local/settings.js"
+import {
+  type LocalSettings,
+  saveFastServingSelection,
+  saveFireworksApiKey,
+  saveFireworksSetup,
+  saveSelectedModel,
+} from "../local/settings.js"
 import { openFireworksKeyPage } from "./provider-links.js"
-import type { ChatUI } from "./ui/types.js"
+import type { ChatUI, SetupInferenceChoice } from "./ui/types.js"
 
 type SetupFlowOptions = {
   ui: ChatUI
   settings: LocalSettings
+  localInferenceUnavailableReason?: string
   isBusy: () => boolean
   setBusy: (busy: boolean) => void
   onCredentialsChanged: (credentials: { fireworksApiKey?: string }) => void
@@ -23,11 +31,11 @@ type SetupFlowOptions = {
     model: CatalogModel,
     options: { signal: AbortSignal; fireworksApiKey?: string },
   ) => Promise<PreparedModelSelection>
-  localLoadStatus?: () => { modelId: string; label: string } | undefined
+  localLoadStatus?: () => { modelId: string; status: ModelPickerStatus } | undefined
   loadedLocalModel?: () => { model: string; contextLength: number } | undefined
   onConfigured: (fireworksApiKey?: string) => void
-  fastMode: () => boolean
-  onFastModeChanged: (fast: boolean) => void
+  fastEnabled: (modelId: string) => boolean
+  onFastChanged: (modelId: string, fast: boolean) => void
 }
 
 export type PreparedModelSelection = {
@@ -44,6 +52,7 @@ export class SetupFlow {
   #selectedModelSupportsImageInput: boolean | undefined
   #models: FireworksModel[] = []
   #persistFireworksApiKey = false
+  #credentialPurpose: "onboarding" | "settings" = "onboarding"
   #wasConfigured = false
   #openedFireworksKeyPage = false
   #catalogController: AbortController | undefined
@@ -61,8 +70,9 @@ export class SetupFlow {
 
   begin() {
     if (this.#closed || this.options.isBusy()) return
+    this.#credentialPurpose = "onboarding"
     if (!this.#fireworksApiKey) {
-      this.requestFireworksKey()
+      this.options.ui.showSetupInferenceChoice()
       return
     }
     if (!this.#selectedModel) {
@@ -76,11 +86,44 @@ export class SetupFlow {
     this.finish()
   }
 
+  selectInference(choice: SetupInferenceChoice) {
+    if (this.#closed || this.options.isBusy()) return
+    this.#credentialPurpose = "onboarding"
+    if (choice === "local") {
+      if (this.options.localInferenceUnavailableReason) {
+        this.options.ui.showSetupInferenceChoice(this.options.localInferenceUnavailableReason)
+        return
+      }
+      this.#fireworksApiKey = this.options.settings.fireworksApiKey
+      this.#models = []
+      this.#persistFireworksApiKey = false
+      this.#openedFireworksKeyPage = false
+      void this.openModelPicker(undefined, this.#selectedModel, false)
+      return
+    }
+    this.requestFireworksKey()
+  }
+
+  configureHostedInference() {
+    if (this.#closed || this.options.isBusy()) return
+    this.#credentialPurpose = "settings"
+    this.#openedFireworksKeyPage = false
+    this.requestFireworksKey()
+  }
+
   async submitCredential(value: string) {
     if (this.#closed) return
     const apiKey = value.trim()
     if (!apiKey) {
-      this.options.ui.showSetupError("Fireworks API key is required.")
+      this.options.ui.showSetupError(
+        "Fireworks API key is required.",
+        this.#credentialPurpose === "settings" ? "configured" : "choice",
+      )
+      return
+    }
+
+    if (this.#credentialPurpose === "settings") {
+      await this.saveHostedCredential(apiKey)
       return
     }
 
@@ -117,7 +160,8 @@ export class SetupFlow {
     return (
       (await this.enqueueSelection(async (signal) => {
         this.options.setBusy(true)
-        const previousFast = this.options.fastMode()
+        const selectedModelId = this.#selectedModel as string
+        const previousFast = this.options.fastEnabled(selectedModelId)
         try {
           const models =
             this.#models.length > 0
@@ -127,13 +171,14 @@ export class SetupFlow {
           if (!selected?.fastId) return "unavailable" as const
 
           const fast = !isFastFireworksModel(this.#selectedModel as string)
-          this.options.onFastModeChanged(fast)
-          await saveFastMode(fast)
-          await this.persistFireworksSelection(selected, signal)
+          this.options.onFastChanged(selectedModelId, fast)
+          await this.persistFireworksSelection(selected, signal, fast)
           return fast ? ("on" as const) : ("off" as const)
         } catch (error) {
-          this.options.onFastModeChanged(previousFast)
-          if (!signal.aborted && !this.#closed) this.options.ui.showSetupError(errorMessage(error))
+          this.options.onFastChanged(selectedModelId, previousFast)
+          if (!signal.aborted && !this.#closed) {
+            this.options.ui.showTransientHint(` Could not change Fast serving: ${errorMessage(error)} `)
+          }
           return signal.aborted ? ("unavailable" as const) : ("error" as const)
         } finally {
           this.options.setBusy(false)
@@ -150,7 +195,7 @@ export class SetupFlow {
       return
     }
     this.options.ui.showHomeLayout()
-    this.options.ui.showSetupButton()
+    this.options.ui.showSetupInferenceChoice()
   }
 
   async cancelModelSelection() {
@@ -174,10 +219,41 @@ export class SetupFlow {
   }
 
   private requestFireworksKey() {
-    this.options.ui.showSetupInput()
+    this.options.ui.showSetupInput("", this.#credentialPurpose === "settings" ? "configured" : "choice")
     if (this.#openedFireworksKeyPage) return
     this.#openedFireworksKeyPage = true
     void openFireworksKeyPage()
+  }
+
+  private async saveHostedCredential(apiKey: string) {
+    await this.runCatalogOperation((signal) => this.persistHostedCredential(apiKey, signal))
+  }
+
+  private async persistHostedCredential(apiKey: string, signal: AbortSignal) {
+    if (this.#closed || this.options.isBusy()) return
+    this.options.setBusy(true)
+    this.options.ui.showSetupStatus("Checking hosted inference...")
+
+    try {
+      const models = await listToolCapableModels(apiKey, { signal })
+      signal.throwIfAborted()
+      if (models.length === 0) throw new Error("The hosted provider returned no public models with tool support.")
+      await saveFireworksApiKey(apiKey)
+
+      this.#fireworksApiKey = apiKey
+      this.#models = models
+      if (this.#closed) return
+      this.options.onCredentialsChanged({ fireworksApiKey: apiKey })
+      this.options.ui.setConfigured()
+      this.options.ui.showTransientHint(" Hosted inference configured ")
+      this.options.ui.focusInput()
+    } catch (error) {
+      if (!signal.aborted && !this.#closed && !isAbortError(error)) {
+        this.options.ui.showSetupError(errorMessage(error), "configured")
+      }
+    } finally {
+      this.options.setBusy(false)
+    }
   }
 
   private async loadModels(
@@ -214,7 +290,7 @@ export class SetupFlow {
         this.options.ui.setConfigured()
         this.options.ui.focusInput()
       } else {
-        this.options.ui.showSetupError(errorMessage(error))
+        this.options.ui.showSetupInferenceChoice(errorMessage(error))
       }
     } finally {
       this.options.setBusy(false)
@@ -233,11 +309,13 @@ export class SetupFlow {
     try {
       const models = await this.loadVerifiedModels(apiKey, signal)
       const selected = selectDefaultFireworksModel(models)
-      if (!selected) throw new Error("Fireworks returned no public serverless models with tool support.")
+      if (!selected) throw new Error("The hosted provider returned no public models with tool support.")
       await this.persistFireworksSelection(selected, signal)
       if (!signal.aborted && !this.#closed) this.finish(selected)
     } catch (error) {
-      if (!signal.aborted && !this.#closed && !isAbortError(error)) this.options.ui.showSetupError(errorMessage(error))
+      if (!signal.aborted && !this.#closed && !isAbortError(error)) {
+        this.options.ui.showSetupError(errorMessage(error), "choice")
+      }
     } finally {
       this.options.setBusy(false)
     }
@@ -245,7 +323,7 @@ export class SetupFlow {
 
   private async loadVerifiedModels(apiKey: string, signal?: AbortSignal) {
     const models = await listToolCapableModels(apiKey, { signal })
-    if (models.length === 0) throw new Error("Fireworks returned no public serverless models with tool support.")
+    if (models.length === 0) throw new Error("The hosted provider returned no public models with tool support.")
     this.#fireworksApiKey = apiKey
     this.#models = models
     return models
@@ -261,7 +339,10 @@ export class SetupFlow {
       this.options.ui.focusInput()
     } catch (error) {
       if (signal.aborted || this.#closed || isAbortError(error)) return
-      this.options.ui.showSetupError(errorMessage(error))
+      this.options.ui.setModelPickerStatus(selected.id, {
+        label: `Failed: ${errorMessage(error)}`,
+        kind: "error",
+      })
     }
   }
 
@@ -269,7 +350,7 @@ export class SetupFlow {
     const selected = findFireworksModel(this.#models, modelId)
     if (!selected) {
       if (!signal.aborted && !this.#closed) {
-        this.options.ui.showSetupError("Select a model from the verified Fireworks catalog.")
+        this.options.ui.showTransientHint(" Select a model from the verified hosted catalog. ")
       }
       return
     }
@@ -282,20 +363,20 @@ export class SetupFlow {
       this.finish(selected)
     } catch (error) {
       if (signal.aborted || this.#closed || isAbortError(error)) return
-      this.options.ui.hideModelPicker()
-      this.options.ui.showSetupError(errorMessage(error))
+      this.options.ui.showTransientHint(` Could not select model: ${errorMessage(error)} `)
     } finally {
       this.options.setBusy(false)
     }
   }
 
-  private async persistFireworksSelection(selected: FireworksModel, signal: AbortSignal) {
+  private async persistFireworksSelection(selected: FireworksModel, signal: AbortSignal, fast?: boolean) {
     const fireworksApiKey = this.#fireworksApiKey
     if (!fireworksApiKey) throw new Error("Fireworks API key is required.")
     const serving = this.servingModel(selected)
 
     await this.persistSelection(serving, signal, async () => {
-      if (this.#persistFireworksApiKey) await saveFireworksSetup(fireworksApiKey, serving)
+      if (fast !== undefined) await saveFastServingSelection(serving, fast)
+      else if (this.#persistFireworksApiKey) await saveFireworksSetup(fireworksApiKey, serving)
       else await saveSelectedModel(serving)
     })
     this.#persistFireworksApiKey = false
@@ -384,7 +465,7 @@ export class SetupFlow {
   }
 
   private servingModel(model: FireworksModel) {
-    return fireworksServingModel(model, this.options.fastMode())
+    return fireworksServingModel(model, this.options.fastEnabled(model.id))
   }
 }
 

--- a/src/cli/slash-commands.ts
+++ b/src/cli/slash-commands.ts
@@ -6,12 +6,11 @@ export type SlashCommand =
   | { type: "theme-menu" }
   | { type: "theme"; name: string }
   | { type: "model" }
-  | { type: "delete-model"; modelId?: string }
+  | { type: "settings"; setting?: "hosted" | "debug" | "delete-model"; modelId?: string }
   | { type: "fast" }
   | { type: "history" }
   | { type: "new" }
   | { type: "home" }
-  | { type: "debug" }
   | { type: "thinking" }
   | { type: "compact"; instructions?: string }
 
@@ -28,29 +27,30 @@ const CATALOG: readonly CatalogCommand[] = [
   { type: "new", name: "/new", description: "Start a new session" },
   { type: "history", name: "/history", description: "Open session history" },
   { type: "model", name: "/model", description: "Choose a model" },
-  { type: "delete-model", name: "/delete-model", description: "Delete a downloaded local model" },
+  { type: "settings", name: "/settings", description: "Configure Otis" },
   { type: "fast", name: "/fast", description: "Toggle Fast serving" },
   { type: "compact", name: "/compact", description: "Summarize old conversation to free context" },
-  { type: "debug", name: "/debug", description: "Toggle debug messages" },
   { type: "thinking", name: "/thinking", description: "Show or hide model thinking traces" },
   { type: "theme-menu", name: "/theme", description: "Choose a color theme" },
   ...THEME_NAMES.map((theme) => ({ type: "theme" as const, name: `/theme ${theme}`, description: "" })),
   { type: "exit", name: "/exit", description: "Exit Otis" },
 ]
 
-export function slashCommands(options: { fast?: boolean; downloadedModels?: boolean } = {}): CommandSuggestion[] {
-  return CATALOG.filter(
-    (command) =>
-      (command.type !== "fast" || options.fast) && (command.type !== "delete-model" || options.downloadedModels),
-  ).map(({ name, description }) => ({
+export function slashCommands(options: { fast?: boolean } = {}): CommandSuggestion[] {
+  return CATALOG.filter((command) => command.type !== "fast" || options.fast).map(({ name, description }) => ({
     name,
     description,
   }))
 }
 
-export const SLASH_COMMANDS: CommandSuggestion[] = slashCommands({ fast: true, downloadedModels: true })
+export const SLASH_COMMANDS: CommandSuggestion[] = slashCommands({ fast: true })
 
 export function parseSlashCommand(value: string): SlashCommand | undefined {
+  // `/debug` shipped before Debug mode moved into Settings. Keep the command
+  // working without advertising it in the top-level command catalog.
+  if (value === "/debug") return { type: "settings", setting: "debug" }
+  // Keep the former top-level model cleanup command working as a hidden alias.
+  if (value === "/delete-model") return { type: "settings", setting: "delete-model" }
   const exact = CATALOG.find((command) => command.name === value)
   if (exact) return toSlashCommand(exact)
   if (value.startsWith("/compact ")) {
@@ -58,7 +58,17 @@ export function parseSlashCommand(value: string): SlashCommand | undefined {
   }
   if (value.startsWith("/delete-model ")) {
     const modelId = value.slice("/delete-model".length).trim()
-    return modelId ? { type: "delete-model", modelId } : { type: "delete-model" }
+    return { type: "settings", setting: "delete-model", ...(modelId ? { modelId } : {}) }
+  }
+  if (value.startsWith("/settings ")) {
+    const setting = value.slice("/settings".length).trim()
+    if (setting === "hosted" || setting === "debug") return { type: "settings", setting }
+    if (setting === "delete-model") return { type: "settings", setting: "delete-model" }
+    if (setting.startsWith("delete-model ")) {
+      const modelId = setting.slice("delete-model".length).trim()
+      return { type: "settings", setting: "delete-model", ...(modelId ? { modelId } : {}) }
+    }
+    return undefined
   }
   if (value.startsWith("/theme ")) {
     return { type: "theme", name: value.slice("/theme".length).trim() }

--- a/src/cli/ui/format.ts
+++ b/src/cli/ui/format.ts
@@ -3,6 +3,7 @@ import type { PermissionMode } from "../../permissions/policy.js"
 
 export const CHAT_INPUT_HINT = " [TAB] mode · [ESC] interrupt "
 export const FAST_MODEL_LABEL = "Fast"
+export const LOCAL_DOWNLOADING_LABEL = "Downloading"
 export const LOCAL_LOADING_LABEL = "Loading"
 
 export type AgentPhase = "thinking" | "working"
@@ -60,7 +61,7 @@ export function withFastModelMark(name: string, fast: boolean) {
 export type LocalModelProgress = { phase: "download"; percent: number } | { phase: "loading" }
 
 export function formatLocalLoadStatus(progress: LocalModelProgress) {
-  if (progress.phase === "download") return `${progress.percent}%`
+  if (progress.phase === "download") return `${LOCAL_DOWNLOADING_LABEL} ${progress.percent}%`
   return LOCAL_LOADING_LABEL
 }
 

--- a/src/cli/ui/input-controller.ts
+++ b/src/cli/ui/input-controller.ts
@@ -6,16 +6,22 @@ import {
   type TextRenderable,
 } from "@opentui/core"
 import { colors } from "../theme.js"
+import { colorPulseAmount, SelectionPulse, selectionOutline } from "./color-pulse.js"
 import { bindAccentButton } from "./input-views.js"
-import type { InputMode, Renderer } from "./types.js"
+import type { InputMode, Renderer, SetupInferenceChoice, SetupInputCancelTarget } from "./types.js"
 
 type InputControllerOptions = {
   renderer: Renderer
   configured: boolean
+  localInferenceUnavailableReason?: string
   input: TextareaRenderable
   inputArea: BoxRenderable
   inputBox: BoxRenderable
   setupButtonBox: BoxRenderable
+  setupChoiceBox: BoxRenderable
+  setupChoiceMessage: TextRenderable
+  setupHostedCard: BoxRenderable
+  setupLocalCard: BoxRenderable
   setupContinueButton: BoxRenderable
   setupForm: BoxRenderable
   setupInput: InputRenderable
@@ -26,7 +32,9 @@ type InputControllerOptions = {
   setupStatusBox: BoxRenderable
   welcomeQuit: TextRenderable
   onBeforePrimaryInput: () => void
+  onModeChange?: (mode: InputMode) => void
   onSetup?: () => void
+  onSetupInferenceChoice?: (choice: SetupInferenceChoice) => void
   onSetupSubmit?: (apiKey: string) => void
 }
 
@@ -38,21 +46,54 @@ type SetupKey = {
 
 export class InputController {
   mode: InputMode
+  #setupInferenceChoice: SetupInferenceChoice = "local"
+  #setupInputCancelTarget: SetupInputCancelTarget = "choice"
+  readonly #setupChoicePulse: SelectionPulse
 
   constructor(private readonly options: InputControllerOptions) {
     this.mode = options.configured ? "chat" : "setupButton"
+    if (options.localInferenceUnavailableReason) this.#setupInferenceChoice = "hosted"
+    this.#setupChoicePulse = new SelectionPulse(options.renderer, (elapsed) => this.#paintInferenceChoice(elapsed))
     options.setupInput.on(InputRenderableEvents.ENTER, () => this.#submitSetup())
     bindAccentButton(options.setupStartButton, options.renderer, () => options.onSetup?.())
     bindAccentButton(options.setupContinueButton, options.renderer, () => this.#submitSetup())
+    bindAccentButton(options.setupLocalCard, options.renderer, () => this.#selectInferenceChoice("local"))
+    bindAccentButton(options.setupHostedCard, options.renderer, () => this.#selectInferenceChoice("hosted"))
   }
 
   handleKey(key: SetupKey) {
-    if (this.mode !== "setupButton") return false
-    if (key.name !== "return" && key.name !== "enter") return false
-    key.preventDefault()
-    key.stopPropagation()
-    this.options.onSetup?.()
-    return true
+    if (this.mode === "setupInput" && key.name === "escape") {
+      stopKey(key)
+      if (this.#setupInputCancelTarget === "configured") this.setConfigured()
+      else this.showSetupInferenceChoice()
+      return true
+    }
+    if (this.mode === "setupButton") {
+      if (key.name !== "return" && key.name !== "enter") return false
+      stopKey(key)
+      this.options.onSetup?.()
+      return true
+    }
+    if (this.mode !== "setupChoice") return false
+    if (["left", "right", "up", "down"].includes(key.name)) {
+      stopKey(key)
+      this.#setupInferenceChoice =
+        !this.options.localInferenceUnavailableReason && (key.name === "left" || key.name === "up") ? "local" : "hosted"
+      this.#paintInferenceChoice()
+      this.options.renderer.requestRender()
+      return true
+    }
+    if (key.name === "return" || key.name === "enter") {
+      stopKey(key)
+      this.options.onSetupInferenceChoice?.(this.#setupInferenceChoice)
+      return true
+    }
+    if (key.name === "escape") {
+      stopKey(key)
+      this.#showSetupButton()
+      return true
+    }
+    return false
   }
 
   clear() {
@@ -73,15 +114,25 @@ export class InputController {
     this.focus()
   }
 
-  showSetupButton() {
+  #showSetupButton() {
     this.clearSetupInput()
     this.mode = "setupButton"
     this.options.welcomeQuit.content = " "
     this.setPrimary(this.options.setupButtonBox)
   }
 
-  showSetup(message = "") {
+  showSetupInferenceChoice(message = "") {
     this.clearSetupInput()
+    this.mode = "setupChoice"
+    this.options.welcomeQuit.content = " "
+    this.#setSetupChoiceMessage(message || this.options.localInferenceUnavailableReason || "")
+    this.setPrimary(this.options.setupChoiceBox)
+    this.#setupChoicePulse.start()
+  }
+
+  showSetup(message = "", cancelTarget: SetupInputCancelTarget = "choice") {
+    this.clearSetupInput()
+    this.#setupInputCancelTarget = cancelTarget
     this.mode = "setupInput"
     this.options.setupInputLabel.content = "Fireworks API key"
     this.options.welcomeQuit.content = " "
@@ -90,8 +141,8 @@ export class InputController {
     this.focus()
   }
 
-  showSetupError(message: string) {
-    this.showSetup(message)
+  showSetupError(message: string, cancelTarget: SetupInputCancelTarget) {
+    this.showSetup(message, cancelTarget)
     this.#setSetupMessage(message, true)
   }
 
@@ -112,8 +163,13 @@ export class InputController {
 
   private setPrimary(renderable: BoxRenderable) {
     this.options.onBeforePrimaryInput()
+    this.options.onModeChange?.(this.mode)
+    if (renderable !== this.options.setupChoiceBox) this.#setupChoicePulse.stop()
+    this.options.input.blur()
+    this.options.setupInput.blur()
     this.options.inputArea.remove(this.options.inputBox.id)
     this.options.inputArea.remove(this.options.setupButtonBox.id)
+    this.options.inputArea.remove(this.options.setupChoiceBox.id)
     this.options.inputArea.remove(this.options.setupForm.id)
     this.options.inputArea.remove(this.options.setupStatusBox.id)
     this.options.inputArea.add(renderable, 0)
@@ -129,6 +185,42 @@ export class InputController {
     this.options.onSetupSubmit?.(this.options.setupInput.value)
   }
 
+  #selectInferenceChoice(choice: SetupInferenceChoice) {
+    if (this.mode !== "setupChoice") return
+    if (choice === "local" && this.options.localInferenceUnavailableReason) {
+      this.#setupInferenceChoice = "hosted"
+      this.#setSetupChoiceMessage(this.options.localInferenceUnavailableReason)
+      this.#paintInferenceChoice()
+      return
+    }
+    this.#setupInferenceChoice = choice
+    this.#paintInferenceChoice()
+    this.options.renderer.requestRender()
+    this.options.onSetupInferenceChoice?.(choice)
+  }
+
+  #paintInferenceChoice(elapsedMs = this.#setupChoicePulse.elapsed()) {
+    this.#paintInferenceCard(this.options.setupLocalCard, "local", elapsedMs)
+    this.#paintInferenceCard(this.options.setupHostedCard, "hosted", elapsedMs)
+  }
+
+  #paintInferenceCard(card: BoxRenderable, value: SetupInferenceChoice, elapsedMs: number) {
+    const selected = this.#setupInferenceChoice === value
+    card.borderColor = selected ? selectionOutline(colorPulseAmount(elapsedMs)) : colors.border
+  }
+
+  #setSetupChoiceMessage(message: string) {
+    const { setupChoiceBox, setupChoiceMessage } = this.options
+    setupChoiceMessage.content = message
+    const mounted = setupChoiceBox.getChildren().some((child) => child.id === setupChoiceMessage.id)
+    if (message) {
+      if (!mounted) setupChoiceBox.add(setupChoiceMessage, 3)
+    } else if (mounted) {
+      setupChoiceBox.remove(setupChoiceMessage.id)
+    }
+    this.options.renderer.requestRender()
+  }
+
   #setSetupMessage(message: string, error: boolean) {
     const { setupForm, setupMessage } = this.options
     setupMessage.content = message
@@ -141,4 +233,9 @@ export class InputController {
     }
     this.options.renderer.requestRender()
   }
+}
+
+function stopKey(key: SetupKey) {
+  key.preventDefault()
+  key.stopPropagation()
 }

--- a/src/cli/ui/input-views.ts
+++ b/src/cli/ui/input-views.ts
@@ -88,21 +88,93 @@ export function createSetupViews(renderer: Renderer) {
   setupButtonBox.add(
     new TextRenderable(renderer, {
       id: "setup-why",
-      content: "Otis uses Fireworks as its inference provider.",
-      fg: colors.muted,
+      content: "Your terminal agent, powered by open models.",
+      fg: colors.text,
       selectable: false,
     }),
   )
   setupButtonBox.add(
     new TextRenderable(renderer, {
       id: "setup-local",
-      content: "Your key and sessions stay on this machine.",
+      content: "Inspect files, edit code, run commands, and search the web.",
       fg: colors.muted,
       selectable: false,
+      wrapMode: "word",
     }),
   )
   const setupStartButton = createAccentButton(renderer, "setup-button", "Set up Otis")
   setupButtonBox.add(setupStartButton)
+
+  const setupChoiceBox = new BoxRenderable(renderer, {
+    id: "setup-choice",
+    flexDirection: "column",
+    width: "100%",
+    minWidth: 24,
+    flexShrink: 0,
+    alignItems: "center",
+    backgroundColor: colors.background,
+    gap: 1,
+  })
+  setupChoiceBox.add(
+    new TextRenderable(renderer, {
+      id: "setup-choice-heading",
+      content: "Choose how Otis runs models",
+      fg: colors.text,
+      selectable: false,
+    }),
+  )
+
+  const setupChoiceCards = new BoxRenderable(renderer, {
+    id: "setup-choice-cards",
+    flexDirection: "row",
+    width: "100%",
+    minWidth: 1,
+    flexShrink: 0,
+    alignItems: "stretch",
+    gap: 2,
+  })
+  const setupLocalCard = createInferenceChoiceCard(renderer, {
+    id: "setup-choice-local",
+    title: "Local inference",
+    label: "Runs on your machine",
+    description: "Run open models on your own hardware.",
+    details: [
+      "Recommended hardware:",
+      "Apple silicon · 24 GB+ unified memory",
+      "Linux · 24 GB+ RAM",
+      "Vulkan GPU · 16 GB+ VRAM",
+      "12–19 GB disk per model",
+    ],
+  })
+  const setupHostedCard = createInferenceChoiceCard(renderer, {
+    id: "setup-choice-hosted",
+    title: "Hosted inference",
+    label: "Powered by Fireworks",
+    description: "Fast remote inference with no local hardware requirements.",
+    details: [
+      "Zero Data Retention by default.",
+      "Uses your own Fireworks API key.",
+      "Configure it anytime in Settings.",
+    ],
+  })
+  setupChoiceCards.add(setupLocalCard)
+  setupChoiceCards.add(setupHostedCard)
+  setupChoiceBox.add(setupChoiceCards)
+  const setupChoiceMessage = new TextRenderable(renderer, {
+    id: "setup-choice-message",
+    content: "",
+    fg: colors.pink,
+    selectable: false,
+    truncate: true,
+  })
+  setupChoiceBox.add(
+    new TextRenderable(renderer, {
+      id: "setup-choice-hint",
+      content: "[←→] move · [enter] select",
+      fg: colors.muted,
+      selectable: false,
+    }),
+  )
 
   const setupInput = new InputRenderable(renderer, {
     id: "setup-input",
@@ -180,6 +252,10 @@ export function createSetupViews(renderer: Renderer) {
 
   return {
     setupButtonBox,
+    setupChoiceBox,
+    setupChoiceMessage,
+    setupHostedCard,
+    setupLocalCard,
     setupContinueButton,
     setupForm,
     setupInput,
@@ -189,6 +265,74 @@ export function createSetupViews(renderer: Renderer) {
     setupStatus,
     setupStatusBox,
   }
+}
+
+type InferenceChoiceCardOptions = {
+  id: string
+  title: string
+  label: string
+  description: string
+  details: string[]
+}
+
+function createInferenceChoiceCard(renderer: Renderer, options: InferenceChoiceCardOptions) {
+  const card = new BoxRenderable(renderer, {
+    id: options.id,
+    flexDirection: "column",
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    minWidth: 1,
+    border: true,
+    borderStyle: "rounded",
+    borderColor: colors.border,
+    paddingX: 2,
+    paddingTop: 1,
+    paddingBottom: 0,
+    gap: 0,
+  })
+  const title = new TextRenderable(renderer, {
+    id: `${options.id}-title`,
+    content: options.title,
+    fg: colors.text,
+    alignSelf: "center",
+    selectable: false,
+    wrapMode: "word",
+  })
+  card.add(title)
+  card.add(
+    new TextRenderable(renderer, {
+      id: `${options.id}-label`,
+      content: options.label,
+      fg: colors.accent,
+      alignSelf: "center",
+      selectable: false,
+      wrapMode: "word",
+    }),
+  )
+  card.add(
+    new TextRenderable(renderer, {
+      id: `${options.id}-description`,
+      content: options.description,
+      fg: colors.text,
+      marginTop: 1,
+      selectable: false,
+      wrapMode: "word",
+    }),
+  )
+  options.details.forEach((detail, index) => {
+    card.add(
+      new TextRenderable(renderer, {
+        id: `${options.id}-detail-${index}`,
+        content: detail,
+        fg: colors.muted,
+        ...(index === 0 ? { marginTop: 1 } : {}),
+        selectable: false,
+        wrapMode: "word",
+      }),
+    )
+  })
+  return card
 }
 
 export function createPermissionPrompt(renderer: Renderer) {

--- a/src/cli/ui/layout.ts
+++ b/src/cli/ui/layout.ts
@@ -7,11 +7,20 @@ import type { ChatUIOptions, Renderer } from "./types.js"
 
 const version = process.env.OTIS_VERSION ?? "dev"
 const TOP_BAR_BRAND = " OTIS "
+const HOME_PANEL_WIDTH = "78%"
+const HOME_PANEL_MAX_WIDTH = 72
+const SETUP_CHOICE_PANEL_WIDTH = "88%"
+const SETUP_CHOICE_PANEL_MAX_WIDTH = 84
 
 export function setTopBarSideMinWidth(start: BoxRenderable, end: BoxRenderable, paddedContext: string) {
   const minWidth = Math.max(TOP_BAR_BRAND.length, paddedContext.length)
   start.minWidth = minWidth
   end.minWidth = minWidth
+}
+
+export function setWelcomePanelExpanded(panel: BoxRenderable, expanded: boolean) {
+  panel.width = expanded ? SETUP_CHOICE_PANEL_WIDTH : HOME_PANEL_WIDTH
+  panel.maxWidth = expanded ? SETUP_CHOICE_PANEL_MAX_WIDTH : HOME_PANEL_MAX_WIDTH
 }
 
 export function createUILayout(
@@ -34,6 +43,10 @@ export function createUILayout(
   })
   const {
     setupButtonBox,
+    setupChoiceBox,
+    setupChoiceMessage,
+    setupHostedCard,
+    setupLocalCard,
     setupContinueButton,
     setupForm,
     setupInput,
@@ -47,8 +60,8 @@ export function createUILayout(
   const welcomePanel = new BoxRenderable(renderer, {
     id: "welcome-panel",
     flexDirection: "column",
-    width: "78%",
-    maxWidth: 72,
+    width: HOME_PANEL_WIDTH,
+    maxWidth: HOME_PANEL_MAX_WIDTH,
     minWidth: 30,
     flexShrink: 0,
     alignSelf: "center",
@@ -295,6 +308,10 @@ export function createUILayout(
     sessionPanel,
     sessionRowsBox,
     setupButtonBox,
+    setupChoiceBox,
+    setupChoiceMessage,
+    setupHostedCard,
+    setupLocalCard,
     setupContinueButton,
     setupForm,
     setupInput,

--- a/src/cli/ui/model-picker.ts
+++ b/src/cli/ui/model-picker.ts
@@ -5,10 +5,11 @@ import {
   type LocalPickerChoice,
   type ModelPickerChoice,
   type ModelPickerItem,
+  type ModelPickerStatus,
 } from "../../inference/picker-catalog.js"
 import { colors } from "../theme.js"
 import { SelectionPulse } from "./color-pulse.js"
-import { FAST_MODEL_LABEL, LOCAL_LOADING_LABEL } from "./format.js"
+import { FAST_MODEL_LABEL } from "./format.js"
 import {
   createPickerRow,
   type PickerRow,
@@ -50,13 +51,13 @@ export class ModelPicker {
     this.#pulse.start()
   }
 
-  setItemStatus(id: string, status: string | undefined) {
+  setItemStatus(id: string, status: ModelPickerStatus | undefined) {
     const item = this.#items.find(
       (candidate): candidate is LocalPickerChoice =>
         candidate.kind === "model" && candidate.provider === "local" && candidate.id === id,
     )
     if (!item) return
-    item.statusLabel = status
+    item.status = status
     this.render()
     this.renderer.requestRender()
   }
@@ -185,8 +186,7 @@ function modelTitle(item: ModelPickerChoice, hasSuffix: boolean) {
 
 function localNameSuffix(item: ModelPickerChoice) {
   if (item.provider !== "local") return undefined
-  if (item.statusLabel === LOCAL_LOADING_LABEL) return { text: item.statusLabel, shimmer: true }
-  if (item.statusLabel) return { text: item.statusLabel }
+  if (item.status) return { text: item.status.label, shimmer: item.status.kind === "progress" }
   if (item.downloaded) return { text: "Downloaded", fg: colors.muted }
   return undefined
 }

--- a/src/cli/ui/overlays.ts
+++ b/src/cli/ui/overlays.ts
@@ -45,7 +45,8 @@ export class OverlayHost {
   #commandMenuVisible = false
   #modelPickerVisible = false
   #sessionPickerVisible = false
-  #themeMenuOpen = false
+  #submenuOpen = false
+  #submenuBack: (() => void) | undefined
 
   constructor(private readonly options: OverlayHostOptions) {}
 
@@ -53,8 +54,8 @@ export class OverlayHost {
     return this.#commandMenuVisible
   }
 
-  get themeMenuOpen() {
-    return this.#themeMenuOpen
+  get submenuOpen() {
+    return this.#submenuOpen
   }
 
   handleKey(key: OverlayKey) {
@@ -73,7 +74,8 @@ export class OverlayHost {
   }
 
   updateCommandMenu(value: string) {
-    this.#themeMenuOpen = false
+    this.#submenuOpen = false
+    this.#submenuBack = undefined
     if (!this.options.commands.update(value, this.options.showingWelcome(), this.options.activeTheme())) {
       this.hideCommandMenu()
       return
@@ -83,12 +85,14 @@ export class OverlayHost {
 
   showThemeMenu() {
     this.options.commands.update("/theme ", this.options.showingWelcome(), this.options.activeTheme())
-    this.#themeMenuOpen = true
+    this.#submenuOpen = true
+    this.#submenuBack = undefined
     this.#showCommandMenu()
   }
 
-  showCommandSubmenu(items: readonly CommandSuggestion[]) {
-    this.#themeMenuOpen = false
+  showCommandSubmenu(items: readonly CommandSuggestion[], options: { onBack?: () => void } = {}) {
+    this.#submenuOpen = true
+    this.#submenuBack = options.onBack
     this.options.commands.showSubmenu(items)
     this.#showCommandMenu()
   }
@@ -97,7 +101,8 @@ export class OverlayHost {
     if (!this.#commandMenuVisible) return
     this.options.inputArea.remove(this.options.commandMenu.id)
     this.#commandMenuVisible = false
-    this.#themeMenuOpen = false
+    this.#submenuOpen = false
+    this.#submenuBack = undefined
     this.options.commands.clear()
     if (restoreThemePreview) this.options.onCancelThemePreview?.()
     this.options.restoreStatus()
@@ -190,7 +195,15 @@ export class OverlayHost {
 
   #handleCommandMenuKey(key: OverlayKey) {
     const handled = this.options.commands.handleKey(key, {
-      close: (restoreThemePreview) => this.hideCommandMenu(restoreThemePreview),
+      close: (restoreThemePreview) => {
+        if (key.name === "escape" && this.#submenuBack) {
+          const back = this.#submenuBack
+          this.#submenuBack = undefined
+          back()
+          return
+        }
+        this.hideCommandMenu(restoreThemePreview)
+      },
       select: (command: CommandSuggestion) => this.#selectCommand(command, command.name),
       preview: (command) => {
         const theme = themeFromCommand(command.name)

--- a/src/cli/ui/types.ts
+++ b/src/cli/ui/types.ts
@@ -1,5 +1,5 @@
 import type { TreeSitterClient } from "@opentui/core"
-import type { ModelPickerItem } from "../../inference/picker-catalog.js"
+import type { ModelPickerItem, ModelPickerStatus } from "../../inference/picker-catalog.js"
 import type { ThemeName } from "../../local/settings.js"
 import type { LocalStats } from "../../local/stats.js"
 import type { SessionPickerItem } from "../session-metadata.js"
@@ -9,7 +9,10 @@ import type { AgentPhase } from "./format.js"
 
 export type Renderer = Awaited<ReturnType<typeof import("@opentui/core").createCliRenderer>>
 
-export type InputMode = "chat" | "inactive" | "setupButton" | "setupInput" | "setupStatus"
+export type SetupInferenceChoice = "local" | "hosted"
+export type SetupInputCancelTarget = "choice" | "configured"
+
+export type InputMode = "chat" | "inactive" | "setupButton" | "setupChoice" | "setupInput" | "setupStatus"
 
 export type CommandSuggestion = {
   name: string
@@ -21,6 +24,7 @@ export type { ModelPickerItem }
 
 export type ChatUIOptions = {
   configured?: boolean
+  localInferenceUnavailableReason?: string
   commands?: CommandSuggestion[]
   contextLabel: string
   modelLabel: string
@@ -37,6 +41,7 @@ export type ChatUIOptions = {
   onInterrupt?: () => void
   onQuit?: () => void | Promise<void>
   onSetup?: () => void
+  onSetupInferenceChoice?: (choice: SetupInferenceChoice) => void
   onSetupSubmit?: (apiKey: string) => void
   onCloseModelPicker?: () => void
   onSelectModel?: (model: ModelPickerItem) => void
@@ -63,7 +68,7 @@ export type ChatUI = {
   setModeLabel(label: string): void
   setImageAttachmentCount(count: number): void
   setModelLabel(label: string): void
-  setModelPickerStatus(modelId: string, status: string | undefined): void
+  setModelPickerStatus(modelId: string, status: ModelPickerStatus | undefined): void
   setCommands(commands: CommandSuggestion[]): void
   setConfigured(): void
   setSessionLabel(label: string): void
@@ -72,11 +77,12 @@ export type ChatUI = {
   setThinkingVisible(visible: boolean): void
   showStats(): void
   showTransientHint(content: string): void
-  showCommandSubmenu(items: CommandSuggestion[]): void
+  showCommandSubmenu(items: CommandSuggestion[], options?: { onBack?: () => void }): void
+  showSlashCommandMenu(): void
   showModelPicker(items: ModelPickerItem[]): void
-  showSetupError(message: string): void
-  showSetupButton(): void
-  showSetupInput(message?: string): void
+  showSetupError(message: string, cancelTarget: SetupInputCancelTarget): void
+  showSetupInferenceChoice(message?: string): void
+  showSetupInput(message?: string, cancelTarget?: SetupInputCancelTarget): void
   showSetupStatus(message?: string): void
   showPermissionPrompt(detail: string): Promise<boolean>
   showSessionPicker(items: SessionPickerItem[]): void

--- a/src/inference/file-integrity.ts
+++ b/src/inference/file-integrity.ts
@@ -1,0 +1,14 @@
+import { createHash } from "node:crypto"
+import { createReadStream } from "node:fs"
+
+export async function sha256File(path: string) {
+  const hash = createHash("sha256")
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest("hex")
+}
+
+export function normalizedSha256(value: string) {
+  const digest = value.toLowerCase().replace(/^sha256:/, "")
+  if (!/^[a-f0-9]{64}$/.test(digest)) throw new Error("Expected a valid SHA-256 digest.")
+  return digest
+}

--- a/src/inference/gguf-cache.ts
+++ b/src/inference/gguf-cache.ts
@@ -1,8 +1,13 @@
-import { randomUUID } from "node:crypto"
-import { mkdir, open, rename, rm, stat } from "node:fs/promises"
+import { createHash, randomUUID } from "node:crypto"
+import { createReadStream } from "node:fs"
+import { mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { llamaModelCacheDirectory } from "../local/paths.js"
+import { normalizedSha256, sha256File } from "./file-integrity.js"
 import { LOCAL_MODELS, type LocalModelSpec } from "./local-catalog.js"
+
+const DOWNLOAD_LOCK_POLL_MS = 250
+const GGUF_MANIFEST_VERSION = 1
 
 export function localGgufPath(model: LocalModelSpec, dataDirectory?: string) {
   const root = dataDirectory ? join(dataDirectory, "models") : llamaModelCacheDirectory()
@@ -10,13 +15,13 @@ export function localGgufPath(model: LocalModelSpec, dataDirectory?: string) {
 }
 
 export function huggingFaceGgufUrl(model: LocalModelSpec) {
-  return `https://huggingface.co/${model.ggufRepo}/resolve/main/${model.ggufFile}`
+  return `https://huggingface.co/${model.ggufRepo}/resolve/${model.ggufRevision}/${model.ggufFile}`
 }
 
 export async function isLocalGgufDownloaded(model: LocalModelSpec, dataDirectory?: string) {
   try {
     const info = await stat(localGgufPath(model, dataDirectory))
-    return info.isFile() && info.size > 0
+    return info.isFile() && info.size === model.weightBytes
   } catch {
     return false
   }
@@ -30,7 +35,18 @@ export async function listDownloadedLocalModels(dataDirectory?: string) {
 }
 
 export async function deleteLocalGguf(model: LocalModelSpec, dataDirectory?: string) {
-  await rm(localGgufPath(model, dataDirectory), { force: true })
+  const dest = localGgufPath(model, dataDirectory)
+  await mkdir(dirname(dest), { recursive: true, mode: 0o700 })
+  const releaseLock = await acquireDownloadLock(lockPath(dest))
+  try {
+    await Promise.all([
+      rm(dest, { force: true }),
+      rm(manifestPath(dest), { force: true }),
+      rm(partialPath(dest), { force: true }),
+    ])
+  } finally {
+    await releaseLock()
+  }
 }
 
 export type DownloadGgufOptions = {
@@ -43,70 +59,297 @@ export type DownloadGgufOptions = {
 
 export async function ensureLocalGguf(model: LocalModelSpec, options: DownloadGgufOptions = {}) {
   const dest = localGgufPath(model, options.dataDirectory)
-  if (await isLocalGgufDownloaded(model, options.dataDirectory)) return dest
-
-  options.signal?.throwIfAborted()
-  const fetchImpl = options.fetch ?? fetch
-  const headers: Record<string, string> = { "user-agent": "otis" }
-  const token = huggingFaceToken(options.env ?? process.env)
-  if (token) headers.authorization = `Bearer ${token}`
-
-  const response = await fetchImpl(huggingFaceGgufUrl(model), {
-    headers,
-    signal: options.signal,
-    redirect: "follow",
-  })
-  if (!response.ok || !response.body) {
-    throw new Error(`Could not download ${model.displayName} (HTTP ${response.status}).`)
-  }
-
-  const contentLength = Number(response.headers.get("content-length"))
-  const expectedBytes = Number.isSafeInteger(contentLength) && contentLength > 0 ? contentLength : undefined
-  const total = expectedBytes ?? model.weightBytes
+  const expectedSha256 = normalizedSha256(model.ggufSha256)
   await mkdir(dirname(dest), { recursive: true, mode: 0o700 })
-  const partial = `${dest}.${process.pid}.${randomUUID()}.partial`
-  const file = await open(partial, "wx", 0o600)
-  let received = 0
-  let lastPercent = -1
-  let closed = false
+  const releaseLock = await acquireDownloadLock(lockPath(dest), options.signal)
   try {
-    const reader = response.body.getReader()
-    for (;;) {
-      const { done, value } = await reader.read()
-      if (done) break
-      options.signal?.throwIfAborted()
-      if (!value || value.byteLength === 0) continue
-      await file.write(value)
-      received += value.byteLength
-      const percent = total > 0 ? Math.min(100, Math.floor((received / total) * 100)) : 0
-      if (percent !== lastPercent) {
-        lastPercent = percent
-        options.onProgress?.(percent)
-      }
+    if (await isVerifiedGguf(dest, model, expectedSha256)) return dest
+
+    const partial = partialPath(dest)
+    const resumedBytes = await validPartialSize(partial, model.weightBytes, expectedSha256)
+    if (resumedBytes === model.weightBytes) {
+      await publishGguf(partial, dest, model, expectedSha256)
+      options.onProgress?.(100)
+      return dest
     }
-    if (received === 0) throw new Error(`Could not download ${model.displayName}: the response was empty.`)
-    if (expectedBytes !== undefined && received !== expectedBytes) {
-      throw new Error(
-        `Could not download ${model.displayName}: expected ${expectedBytes} bytes but received ${received}.`,
-      )
+
+    options.signal?.throwIfAborted()
+    const headers: Record<string, string> = { "user-agent": "otis" }
+    const token = huggingFaceToken(options.env ?? process.env)
+    if (token) headers.authorization = `Bearer ${token}`
+    if (resumedBytes > 0) headers.range = `bytes=${resumedBytes}-`
+
+    const fetchImpl = options.fetch ?? fetch
+    const response = await fetchImpl(huggingFaceGgufUrl(model), {
+      headers,
+      signal: options.signal,
+      redirect: "follow",
+    })
+    if (!response.ok || !response.body) {
+      throw new Error(`Could not download ${model.displayName} (HTTP ${response.status}).`)
     }
-    await file.close()
-    closed = true
+
+    const append = resumedBytes > 0 && response.status === 206
+    const start = append ? resumedBytes : 0
+    validateDownloadResponse(response, start, model)
+    const hash = createHash("sha256")
+    if (start > 0) await updateHashFromFile(hash, partial)
+    const file = await open(partial, append ? "a" : "w", 0o600)
+    let received = start
+    let lastPercent = downloadPercent(received, model.weightBytes)
+    let closed = false
+    let discardPartial = false
+    options.onProgress?.(lastPercent)
     try {
-      await rename(partial, dest)
-    } catch (error) {
-      // A concurrent downloader may have published the same model first on
-      // platforms that do not replace an existing destination during rename.
-      if (!(await isLocalGgufDownloaded(model, options.dataDirectory))) throw error
+      const reader = response.body.getReader()
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        options.signal?.throwIfAborted()
+        if (!value || value.byteLength === 0) continue
+        if (received + value.byteLength > model.weightBytes) {
+          discardPartial = true
+          throw new Error(`Could not download ${model.displayName}: the response exceeded the pinned file size.`)
+        }
+        await file.writeFile(value)
+        hash.update(value)
+        received += value.byteLength
+        const percent = downloadPercent(received, model.weightBytes)
+        if (percent !== lastPercent) {
+          lastPercent = percent
+          options.onProgress?.(percent)
+        }
+      }
+      options.signal?.throwIfAborted()
+      if (received !== model.weightBytes) {
+        throw new Error(
+          `Could not download ${model.displayName}: expected ${model.weightBytes} bytes but received ${received}.`,
+        )
+      }
+      const actualSha256 = hash.digest("hex")
+      if (actualSha256 !== expectedSha256) {
+        discardPartial = true
+        throw new Error(`Could not download ${model.displayName}: SHA-256 verification failed.`)
+      }
+      await file.close()
+      closed = true
+      await publishGguf(partial, dest, model, expectedSha256)
+    } finally {
+      if (!closed) await file.close().catch(() => undefined)
+      if (discardPartial) await rm(partial, { force: true }).catch(() => undefined)
     }
+    if (lastPercent !== 100) options.onProgress?.(100)
+    return dest
   } finally {
-    if (!closed) await file.close().catch(() => undefined)
-    await rm(partial, { force: true })
+    await releaseLock()
   }
-  if (lastPercent !== 100) options.onProgress?.(100)
-  return dest
+}
+
+async function isVerifiedGguf(dest: string, model: LocalModelSpec, expectedSha256: string) {
+  try {
+    const info = await stat(dest)
+    if (!info.isFile() || info.size !== model.weightBytes) return false
+  } catch (error) {
+    if (isNotFound(error)) return false
+    throw error
+  }
+  if (await hasMatchingManifest(dest, model, expectedSha256)) return true
+  if ((await sha256File(dest)) !== expectedSha256) return false
+  await writeGgufManifest(dest, model, expectedSha256)
+  return true
+}
+
+async function validPartialSize(partial: string, expectedBytes: number, expectedSha256: string) {
+  try {
+    const info = await stat(partial)
+    if (!info.isFile() || info.size > expectedBytes) {
+      await rm(partial, { force: true })
+      return 0
+    }
+    if (info.size === expectedBytes && (await sha256File(partial)) !== expectedSha256) {
+      await rm(partial, { force: true })
+      return 0
+    }
+    return info.size
+  } catch (error) {
+    if (isNotFound(error)) return 0
+    throw error
+  }
+}
+
+function validateDownloadResponse(response: Response, start: number, model: LocalModelSpec) {
+  if (start > 0) {
+    const contentRange = response.headers.get("content-range")
+    const match = contentRange?.match(/^bytes (\d+)-(\d+)\/(\d+)$/)
+    if (
+      !match ||
+      Number(match[1]) !== start ||
+      Number(match[2]) !== model.weightBytes - 1 ||
+      Number(match[3]) !== model.weightBytes
+    ) {
+      throw new Error(`Could not resume ${model.displayName}: the server returned an invalid byte range.`)
+    }
+  }
+  const contentLengthHeader = response.headers.get("content-length")
+  const contentLength = contentLengthHeader === null ? undefined : Number(contentLengthHeader)
+  const expectedResponseBytes = model.weightBytes - start
+  if (contentLength !== undefined && (!Number.isSafeInteger(contentLength) || contentLength < 0)) {
+    throw new Error(`Could not download ${model.displayName}: the server returned an invalid content length.`)
+  }
+  if (contentLength !== undefined && contentLength !== expectedResponseBytes) {
+    throw new Error(
+      `Could not download ${model.displayName}: expected ${expectedResponseBytes} response bytes but received ${contentLength}.`,
+    )
+  }
+}
+
+async function publishGguf(partial: string, dest: string, model: LocalModelSpec, expectedSha256: string) {
+  await rename(partial, dest)
+  await writeGgufManifest(dest, model, expectedSha256)
+}
+
+async function hasMatchingManifest(dest: string, model: LocalModelSpec, expectedSha256: string) {
+  try {
+    const value = JSON.parse(await readFile(manifestPath(dest), "utf8")) as Record<string, unknown>
+    return (
+      value.version === GGUF_MANIFEST_VERSION &&
+      value.model === model.id &&
+      value.revision === model.ggufRevision &&
+      value.sha256 === expectedSha256 &&
+      value.size === model.weightBytes
+    )
+  } catch {
+    return false
+  }
+}
+
+async function writeGgufManifest(dest: string, model: LocalModelSpec, expectedSha256: string) {
+  const path = manifestPath(dest)
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`
+  try {
+    await writeFile(
+      temporary,
+      `${JSON.stringify({
+        version: GGUF_MANIFEST_VERSION,
+        model: model.id,
+        revision: model.ggufRevision,
+        sha256: expectedSha256,
+        size: model.weightBytes,
+      })}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    )
+    await rename(temporary, path)
+  } finally {
+    await rm(temporary, { force: true })
+  }
+}
+
+async function updateHashFromFile(hash: ReturnType<typeof createHash>, path: string) {
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+}
+
+function downloadPercent(received: number, total: number) {
+  return Math.min(100, Math.floor((received / total) * 100))
+}
+
+function partialPath(dest: string) {
+  return `${dest}.partial`
+}
+
+function manifestPath(dest: string) {
+  return `${dest}.otis.json`
+}
+
+function lockPath(dest: string) {
+  return `${dest}.download.lock`
+}
+
+async function acquireDownloadLock(path: string, signal?: AbortSignal) {
+  for (;;) {
+    signal?.throwIfAborted()
+    try {
+      const handle = await open(path, "wx", 0o600)
+      try {
+        await handle.writeFile(`${JSON.stringify({ pid: process.pid })}\n`, "utf8")
+      } catch (error) {
+        await rm(path, { force: true })
+        throw error
+      } finally {
+        await handle.close().catch(() => undefined)
+      }
+      return async () => {
+        await rm(path, { force: true })
+      }
+    } catch (error) {
+      if (!isAlreadyExists(error)) throw error
+      if (await isStaleLock(path)) {
+        await rm(path, { force: true })
+        continue
+      }
+      await abortableDelay(DOWNLOAD_LOCK_POLL_MS, signal)
+    }
+  }
+}
+
+async function isStaleLock(path: string) {
+  try {
+    const contents = await readFile(path, "utf8")
+    let value: { pid?: unknown }
+    try {
+      value = JSON.parse(contents) as { pid?: unknown }
+    } catch {
+      const info = await stat(path)
+      return Date.now() - info.mtimeMs > 5_000
+    }
+    if (!Number.isSafeInteger(value.pid) || Number(value.pid) <= 0) return true
+    try {
+      process.kill(Number(value.pid), 0)
+      return false
+    } catch (error) {
+      return !isPermissionDenied(error)
+    }
+  } catch (error) {
+    if (isNotFound(error)) return true
+    throw error
+  }
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"))
+      return
+    }
+    const timer = setTimeout(done, ms)
+    const abort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener("abort", abort)
+      reject(signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"))
+    }
+    function done() {
+      signal?.removeEventListener("abort", abort)
+      resolve()
+    }
+    signal?.addEventListener("abort", abort, { once: true })
+  })
 }
 
 function huggingFaceToken(env: NodeJS.ProcessEnv) {
   return env.HF_TOKEN?.trim() || env.HUGGING_FACE_HUB_TOKEN?.trim() || undefined
+}
+
+function isNotFound(error: unknown) {
+  return errorCode(error) === "ENOENT"
+}
+
+function isAlreadyExists(error: unknown) {
+  return errorCode(error) === "EEXIST"
+}
+
+function isPermissionDenied(error: unknown) {
+  return errorCode(error) === "EPERM"
+}
+
+function errorCode(error: unknown) {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined
 }

--- a/src/inference/hardware.ts
+++ b/src/inference/hardware.ts
@@ -1,5 +1,8 @@
 import { execFile } from "node:child_process"
+import { constants } from "node:fs"
+import { access, readdir, readFile } from "node:fs/promises"
 import { totalmem } from "node:os"
+import { join } from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
@@ -13,14 +16,11 @@ export type HardwareProbe = {
   arch: string
   totalMemoryBytes: number
   gpuMemoryBytes?: number
-  gpuMemoryFreeBytes?: number
-  gpuDeviceCount?: number
   backend: HardwareBackend
   unifiedMemory: boolean
 }
 
 export type InferenceMemoryBudget = {
-  availableBytes: number
   deviceHeadroomBytes: number
 }
 
@@ -31,6 +31,11 @@ export type HardwareDetectOptions = {
     totalMemoryBytes?: number
   }
   nvidiaSmi?: () => Promise<string | undefined>
+  linuxGraphics?: () => Promise<readonly LinuxGraphicsDevice[]>
+}
+
+export type LinuxGraphicsDevice = {
+  memoryTotalBytes?: number
 }
 
 export async function detectHardware(options: HardwareDetectOptions = {}): Promise<HardwareProbe> {
@@ -49,17 +54,29 @@ export async function detectHardware(options: HardwareDetectOptions = {}): Promi
     }
   }
 
-  const nvidia = await readNvidiaMemory(options.nvidiaSmi ?? defaultNvidiaSmi)
-  if (nvidia) {
-    return {
-      platform,
-      arch,
-      totalMemoryBytes,
-      gpuMemoryBytes: nvidia.totalBytes,
-      ...(nvidia.freeBytes !== undefined ? { gpuMemoryFreeBytes: nvidia.freeBytes } : {}),
-      gpuDeviceCount: nvidia.deviceCount,
-      backend: platform === "linux" ? "vulkan" : "cpu",
-      unifiedMemory: false,
+  if (platform === "linux") {
+    const nvidia = await readNvidiaMemory(options.nvidiaSmi ?? defaultNvidiaSmi)
+    if (nvidia) {
+      return {
+        platform,
+        arch,
+        totalMemoryBytes,
+        gpuMemoryBytes: nvidia.totalBytes,
+        backend: "vulkan",
+        unifiedMemory: false,
+      }
+    }
+
+    const graphics = await readLinuxGraphics(options.linuxGraphics ?? defaultLinuxGraphics)
+    if (graphics) {
+      return {
+        platform,
+        arch,
+        totalMemoryBytes,
+        ...(graphics.totalBytes !== undefined ? { gpuMemoryBytes: graphics.totalBytes } : {}),
+        backend: "vulkan",
+        unifiedMemory: false,
+      }
     }
   }
 
@@ -72,44 +89,25 @@ export async function detectHardware(options: HardwareDetectOptions = {}): Promi
   }
 }
 
-export function availableInferenceMemory(hardware: HardwareProbe) {
-  return inferenceMemoryBudget(hardware).availableBytes
+/** Host memory available to run a model, including CPU layers used by hybrid offload. */
+export function availableModelMemory(hardware: HardwareProbe) {
+  return Math.max(0, hardware.totalMemoryBytes - roundedHeadroom(reservedSystemMemory(hardware)))
 }
 
 export function inferenceMemoryBudget(hardware: HardwareProbe): InferenceMemoryBudget {
-  const deviceHeadroomBytes = roundedHeadroom(
-    hardware.unifiedMemory || hardware.backend === "cpu" ? reservedSystemMemory(hardware) : GIBIBYTE,
-  )
-  const deviceMemoryBytes =
-    hardware.backend !== "cpu" && hardware.gpuMemoryBytes && hardware.gpuMemoryBytes > 0
-      ? hardware.gpuMemoryBytes
-      : hardware.totalMemoryBytes
-  const deviceCount = hardware.unifiedMemory || hardware.backend === "cpu" ? 1 : (hardware.gpuDeviceCount ?? 1)
-  return {
-    availableBytes: Math.max(0, deviceMemoryBytes - deviceHeadroomBytes * deviceCount),
-    deviceHeadroomBytes,
-  }
-}
-
-/**
- * Memory available to a new inference process right now. Capacity checks use
- * `availableInferenceMemory`; this value is advisory because another Otis
- * server may release its VRAM before the next model starts.
- */
-export function currentlyAvailableInferenceMemory(hardware: HardwareProbe) {
-  const budget = inferenceMemoryBudget(hardware)
-  if (!hardware.unifiedMemory && hardware.backend !== "cpu" && hardware.gpuMemoryFreeBytes !== undefined) {
-    const deviceCount = hardware.gpuDeviceCount ?? 1
-    return Math.min(
-      budget.availableBytes,
-      Math.max(0, hardware.gpuMemoryFreeBytes - budget.deviceHeadroomBytes * deviceCount),
-    )
-  }
-  return budget.availableBytes
+  const hasDedicatedMemory =
+    !hardware.unifiedMemory &&
+    hardware.backend !== "cpu" &&
+    hardware.gpuMemoryBytes !== undefined &&
+    hardware.gpuMemoryBytes > 0
+  const deviceHeadroomBytes = roundedHeadroom(hasDedicatedMemory ? GIBIBYTE : reservedSystemMemory(hardware))
+  return { deviceHeadroomBytes }
 }
 
 function reservedSystemMemory(hardware: HardwareProbe) {
-  if (hardware.unifiedMemory) return Math.max(3 * GIBIBYTE, hardware.totalMemoryBytes * 0.15)
+  if (hardware.platform === "darwin" && hardware.unifiedMemory) {
+    return Math.max(3 * GIBIBYTE, hardware.totalMemoryBytes * 0.15)
+  }
   return Math.max(2 * GIBIBYTE, hardware.totalMemoryBytes * 0.1)
 }
 
@@ -125,20 +123,12 @@ async function readNvidiaMemory(nvidiaSmi: () => Promise<string | undefined>) {
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter(Boolean)
-      .map((line) => line.split(",").map((value) => Number.parseFloat(value.trim())))
-      .filter((values) => Number.isFinite(values[0]) && Number(values[0]) > 0)
+      .map((line) => Number.parseFloat(line))
+      .filter((value) => Number.isFinite(value) && value > 0)
     if (devices.length === 0) return undefined
 
-    const totalMiB = devices.reduce((sum, values) => sum + Number(values[0]), 0)
-    const hasFreeForEveryDevice = devices.every((values) => Number.isFinite(values[1]) && Number(values[1]) >= 0)
-    const freeMiB = hasFreeForEveryDevice
-      ? devices.reduce((sum, values) => sum + Math.min(Number(values[0]), Number(values[1])), 0)
-      : undefined
-    return {
-      totalBytes: Math.round(totalMiB * 1024 * 1024),
-      ...(freeMiB !== undefined ? { freeBytes: Math.round(freeMiB * 1024 * 1024) } : {}),
-      deviceCount: devices.length,
-    }
+    const totalMiB = devices.reduce((sum, value) => sum + value, 0)
+    return { totalBytes: Math.round(totalMiB * 1024 * 1024) }
   } catch {
     return undefined
   }
@@ -146,13 +136,70 @@ async function readNvidiaMemory(nvidiaSmi: () => Promise<string | undefined>) {
 
 async function defaultNvidiaSmi() {
   try {
-    const result = await execFileAsync(
-      "nvidia-smi",
-      ["--query-gpu=memory.total,memory.free", "--format=csv,noheader,nounits"],
-      { timeout: 2_000 },
-    )
+    const result = await execFileAsync("nvidia-smi", ["--query-gpu=memory.total", "--format=csv,noheader,nounits"], {
+      timeout: 2_000,
+    })
     return result.stdout
   } catch {
     return undefined
   }
+}
+
+async function readLinuxGraphics(probe: () => Promise<readonly LinuxGraphicsDevice[]>) {
+  try {
+    const devices = await probe()
+    if (devices.length === 0) return undefined
+    const memory = devices.map((device) => ({
+      total: positiveInteger(device.memoryTotalBytes),
+    }))
+    const hasMemoryForEveryDevice = memory.every(({ total }) => total !== undefined)
+    const totalBytes = hasMemoryForEveryDevice ? memory.reduce((sum, { total }) => sum + (total ?? 0), 0) : undefined
+    return totalBytes === undefined ? {} : { totalBytes }
+  } catch {
+    return undefined
+  }
+}
+
+async function defaultLinuxGraphics(): Promise<LinuxGraphicsDevice[]> {
+  const drmRoot = "/sys/class/drm"
+  const entries = await readdir(drmRoot, { withFileTypes: true })
+  // Entries under /sys/class/drm are commonly symlinks, so the name is the
+  // reliable render-node discriminator rather than Dirent.isDirectory().
+  const renderNodes = entries.filter((entry) => /^renderD\d+$/.test(entry.name))
+  const usableRenderNodes = []
+  for (const entry of renderNodes) {
+    try {
+      await access(join("/dev/dri", entry.name), constants.R_OK | constants.W_OK)
+      usableRenderNodes.push(entry)
+    } catch {
+      // A render node that this process cannot open is not a usable backend.
+    }
+  }
+  return await Promise.all(
+    usableRenderNodes.map(async (entry) => {
+      const deviceRoot = join(drmRoot, entry.name, "device")
+      return {
+        memoryTotalBytes: await readInteger(join(deviceRoot, "mem_info_vram_total")),
+      }
+    }),
+  )
+}
+
+async function readTrimmed(path: string) {
+  try {
+    return (await readFile(path, "utf8")).trim()
+  } catch {
+    return undefined
+  }
+}
+
+async function readInteger(path: string) {
+  const value = await readTrimmed(path)
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function positiveInteger(value: number | undefined) {
+  return value !== undefined && Number.isSafeInteger(value) && value > 0 ? value : undefined
 }

--- a/src/inference/llama-binary.ts
+++ b/src/inference/llama-binary.ts
@@ -1,13 +1,39 @@
-export type GitHubReleaseAsset = {
-  name: string
-  browser_download_url: string
-  size: number
-}
+export const LLAMA_CPP_RELEASE_TAG = "b10622"
 
-export type GitHubRelease = {
-  tag_name: string
-  prerelease?: boolean
-  assets: GitHubReleaseAsset[]
+const LLAMA_CPP_RELEASE_BASE_URL = `https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_RELEASE_TAG}`
+
+const LLAMA_CPP_ASSETS = {
+  "llama-b10622-bin-macos-arm64.tar.gz": {
+    size: 10_954_906,
+    sha256: "c0116ec9957477a9c77e68d3cf31e79f9aede1a9210861c7c09d74acc3e9c3cf",
+  },
+  "llama-b10622-bin-macos-x64.tar.gz": {
+    size: 11_034_210,
+    sha256: "b772320b22bc5cf845930088c985012b94e284242c2ad05fad174297eb5e373e",
+  },
+  "llama-b10622-bin-ubuntu-arm64.tar.gz": {
+    size: 13_042_868,
+    sha256: "6730946e555d57cdd29ad28f9d445a9195fa3d72d5ed076fa6dcfe25a4f4c266",
+  },
+  "llama-b10622-bin-ubuntu-vulkan-arm64.tar.gz": {
+    size: 26_775_532,
+    sha256: "743e7d3ee6297daa22cdc5b2262ebed93512bdffaf3d5c7f05c24ff60e7e78cb",
+  },
+  "llama-b10622-bin-ubuntu-vulkan-x64.tar.gz": {
+    size: 32_916_111,
+    sha256: "2e9a07037f1aa89f9ccd85acc6a376c503a369e3feb916b42d8e9a1542c8828e",
+  },
+  "llama-b10622-bin-ubuntu-x64.tar.gz": {
+    size: 16_291_802,
+    sha256: "6cc895c67bfa868faccda8aca06ec136e489609fc20f068550214f149d94fb4c",
+  },
+} as const
+
+export type LlamaCppAsset = {
+  name: keyof typeof LLAMA_CPP_ASSETS
+  url: string
+  size: number
+  sha256: string
 }
 
 export type LlamaBinaryTarget = {
@@ -16,31 +42,37 @@ export type LlamaBinaryTarget = {
   backend: "metal" | "vulkan" | "cpu"
 }
 
-export function selectLlamaCppAsset(release: GitHubRelease, target: LlamaBinaryTarget) {
-  const wanted = assetNameFor(release.tag_name, target)
-  const asset = release.assets.find((candidate) => candidate.name === wanted)
-  if (!asset) {
-    throw new Error(`llama.cpp ${release.tag_name} does not include ${wanted}.`)
-  }
-  return asset
+export function supportsLlamaCppTarget(target: Pick<LlamaBinaryTarget, "platform" | "arch">) {
+  return (
+    (target.platform === "darwin" || target.platform === "linux") && (target.arch === "arm64" || target.arch === "x64")
+  )
 }
 
-export function assetNameFor(tag: string, target: LlamaBinaryTarget) {
-  if (target.platform === "darwin" && target.arch === "arm64") return `llama-${tag}-bin-macos-arm64.tar.gz`
-  if (target.platform === "darwin" && target.arch === "x64") return `llama-${tag}-bin-macos-x64.tar.gz`
+export function unsupportedLlamaCppTargetMessage(target: Pick<LlamaBinaryTarget, "platform" | "arch">) {
+  return `Local inference is not supported on ${target.platform}/${target.arch}.`
+}
+
+export function pinnedLlamaCppAsset(target: LlamaBinaryTarget): LlamaCppAsset {
+  const name = assetName(target)
+  return { name, url: `${LLAMA_CPP_RELEASE_BASE_URL}/${name}`, ...LLAMA_CPP_ASSETS[name] }
+}
+
+function assetName(target: LlamaBinaryTarget): keyof typeof LLAMA_CPP_ASSETS {
+  if (target.platform === "darwin" && target.arch === "arm64") {
+    return `llama-${LLAMA_CPP_RELEASE_TAG}-bin-macos-arm64.tar.gz`
+  }
+  if (target.platform === "darwin" && target.arch === "x64") {
+    return `llama-${LLAMA_CPP_RELEASE_TAG}-bin-macos-x64.tar.gz`
+  }
   if (target.platform === "linux" && target.arch === "arm64") {
     return target.backend === "cpu"
-      ? `llama-${tag}-bin-ubuntu-arm64.tar.gz`
-      : `llama-${tag}-bin-ubuntu-vulkan-arm64.tar.gz`
+      ? `llama-${LLAMA_CPP_RELEASE_TAG}-bin-ubuntu-arm64.tar.gz`
+      : `llama-${LLAMA_CPP_RELEASE_TAG}-bin-ubuntu-vulkan-arm64.tar.gz`
   }
   if (target.platform === "linux" && target.arch === "x64") {
-    return target.backend === "cpu" ? `llama-${tag}-bin-ubuntu-x64.tar.gz` : `llama-${tag}-bin-ubuntu-vulkan-x64.tar.gz`
+    return target.backend === "cpu"
+      ? `llama-${LLAMA_CPP_RELEASE_TAG}-bin-ubuntu-x64.tar.gz`
+      : `llama-${LLAMA_CPP_RELEASE_TAG}-bin-ubuntu-vulkan-x64.tar.gz`
   }
-  throw new Error(`Local models are not supported on ${target.platform}/${target.arch}.`)
-}
-
-export function latestLlamaCppRelease(releases: readonly GitHubRelease[]) {
-  const release = releases.find((candidate) => /^b\d+$/.test(candidate.tag_name) && candidate.assets.length > 0)
-  if (!release) throw new Error("Could not find a llama.cpp build with downloadable binaries.")
-  return release
+  throw new Error(unsupportedLlamaCppTargetMessage(target))
 }

--- a/src/inference/llama-runtime.ts
+++ b/src/inference/llama-runtime.ts
@@ -1,5 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process"
-import { chmod, mkdir, mkdtemp, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import type { Dirent } from "node:fs"
+import { chmod, mkdir, mkdtemp, open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
@@ -7,11 +9,16 @@ import { childProcessEnvironment } from "../local/child-environment.js"
 import { llamaBinaryDirectory, llamaModelCacheDirectory } from "../local/paths.js"
 import { ensureLocalGguf } from "./gguf-cache.js"
 import { type HardwareProbe, inferenceMemoryBudget } from "./hardware.js"
-import { type GitHubRelease, latestLlamaCppRelease, selectLlamaCppAsset } from "./llama-binary.js"
+import {
+  LLAMA_CPP_RELEASE_TAG,
+  type LlamaCppAsset,
+  pinnedLlamaCppAsset,
+  supportsLlamaCppTarget,
+  unsupportedLlamaCppTargetMessage,
+} from "./llama-binary.js"
 import { LOCAL_MIN_CONTEXT_LENGTH, type LocalModelSpec } from "./local-catalog.js"
 import type { LocalModelFit } from "./local-fit.js"
 
-const GITHUB_RELEASES_URL = "https://api.github.com/repos/ggml-org/llama.cpp/releases?per_page=20"
 const DEFAULT_READY_TIMEOUT_MS = 30 * 60 * 1000
 const STOP_TIMEOUT_MS = 5_000
 const KILL_WAIT_MS = 1_000
@@ -36,6 +43,7 @@ export type LlamaCppRuntimeOptions = {
   spawn?: typeof spawn
   extractArchive?: (archivePath: string, destination: string) => Promise<void>
   allocatePort?: () => Promise<number>
+  runtimeAsset?: (target: Parameters<typeof pinnedLlamaCppAsset>[0]) => LlamaCppAsset
   dataDirectory?: string
   readyTimeoutMs?: number
   sleep?: (ms: number) => Promise<void>
@@ -63,10 +71,11 @@ export class LlamaCppRuntime {
     hardware: HardwareProbe,
     options: EnsureServingOptions = {},
   ): Promise<LocalServingEndpoint> {
+    if (!supportsLlamaCppTarget(hardware)) throw new Error(unsupportedLlamaCppTargetMessage(hardware))
     if (!fit.available) {
       throw new Error(`${model.displayName} needs ${formatBytes(fit.memoryRequiredBytes)} to run on this machine.`)
     }
-    const key = `${model.id}:${fit.contextLength}`
+    const key = servingKey(model, hardware)
     if (
       this.#servingKey === key &&
       this.#serving?.model === model.id &&
@@ -129,6 +138,7 @@ export class LlamaCppRuntime {
     onProgress?.({ phase: "loading" })
 
     const port = await (this.#options.allocatePort ?? allocatePort)()
+    signal.throwIfAborted()
     const inferenceURL = `http://127.0.0.1:${port}/v1/chat/completions`
     const env = this.#options.env ?? process.env
     const childEnv = llamaServerEnvironment(
@@ -141,10 +151,9 @@ export class LlamaCppRuntime {
       stdio: ["ignore", "pipe", "pipe"],
     })
     this.#process = child
-    const logs: string[] = []
+    const logs = { value: "" }
     const append = (chunk: Buffer | string) => {
-      logs.push(String(chunk))
-      if (logs.join("").length > 20_000) logs.splice(0, logs.length - 1)
+      logs.value = `${logs.value}${String(chunk)}`.slice(-20_000)
     }
     child.stdout?.on("data", append)
     child.stderr?.on("data", append)
@@ -174,55 +183,49 @@ export class LlamaCppRuntime {
     const binaryRoot = this.#options.dataDirectory
       ? join(this.#options.dataDirectory, "bin")
       : dirname(llamaBinaryDirectory("release"))
-    const cached = await findCachedLlamaServer(binaryRoot, hardware)
-    if (cached) return cached
-
-    const fetchImpl = this.#options.fetch ?? fetch
-    const response = await fetchImpl(GITHUB_RELEASES_URL, {
-      headers: { accept: "application/vnd.github+json", "user-agent": "otis" },
-      signal,
-    })
-    if (!response.ok) throw new Error(`Could not load llama.cpp releases (HTTP ${response.status}).`)
-    const releases = (await response.json()) as GitHubRelease[]
-    if (!Array.isArray(releases)) throw new Error("llama.cpp releases response was invalid.")
-    const release = latestLlamaCppRelease(releases)
-    const asset = selectLlamaCppAsset(release, {
+    const binaryDir = join(binaryRoot, LLAMA_CPP_RELEASE_TAG)
+    const binaryPath = join(binaryDir, "llama-server")
+    const asset = (this.#options.runtimeAsset ?? pinnedLlamaCppAsset)({
       platform: hardware.platform,
       arch: hardware.arch,
       backend: hardware.backend,
     })
-    const binaryDir = join(binaryRoot, release.tag_name)
-    const binaryPath = join(binaryDir, "llama-server")
-    if (await isUsableRuntimeBundle(binaryDir, hardware)) return binaryPath
+    const cached = await findCachedLlamaServer(binaryDir, hardware, asset.sha256)
+    if (cached) {
+      await removeUnpinnedRuntimeBundles(binaryRoot)
+      return cached
+    }
 
+    const fetchImpl = this.#options.fetch ?? fetch
     await mkdir(binaryRoot, { recursive: true, mode: 0o700 })
-    const download = await downloadToTemp(asset.browser_download_url, fetchImpl, signal)
+    const download = await downloadToTemp(asset, fetchImpl, signal)
     let extractDir: string | undefined
     let candidateDir: string | undefined
     try {
-      extractDir = await mkdtemp(join(binaryRoot, `.${safePathSegment(release.tag_name)}-extract-`))
+      extractDir = await mkdtemp(join(binaryRoot, `.${LLAMA_CPP_RELEASE_TAG}-extract-`))
       candidateDir = `${extractDir}.bundle`
       await (this.#options.extractArchive ?? extractTarGz)(download.archivePath, extractDir)
       signal?.throwIfAborted()
       const found = await findNamedFile(extractDir, "llama-server")
       if (!found) throw new Error("llama.cpp archive did not include llama-server.")
       await chmod(found, 0o755)
-      await writeRuntimeManifest(dirname(found), release.tag_name, hardware)
+      await writeRuntimeManifest(dirname(found), LLAMA_CPP_RELEASE_TAG, hardware, asset.sha256)
 
       // llama-server dynamically loads the libraries and backend assets shipped
       // beside it. Publish that directory atomically as one runtime bundle.
       await rename(dirname(found), candidateDir)
-      await publishRuntimeBundle(candidateDir, binaryDir, `${extractDir}.previous`, hardware)
+      await publishRuntimeBundle(candidateDir, binaryDir, `${extractDir}.previous`, hardware, asset.sha256)
     } finally {
       if (extractDir) await rm(extractDir, { recursive: true, force: true })
       if (candidateDir) await rm(candidateDir, { recursive: true, force: true })
       await rm(download.directory, { recursive: true, force: true })
     }
     await assertExecutable(binaryPath)
+    await removeUnpinnedRuntimeBundles(binaryRoot)
     return binaryPath
   }
 
-  async #waitUntilReady(port: number, child: ChildProcess, logs: string[], signal: AbortSignal) {
+  async #waitUntilReady(port: number, child: ChildProcess, logs: { value: string }, signal: AbortSignal) {
     const timeoutMs = this.#options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
     const sleep = this.#options.sleep ?? delay
     const fetchImpl = this.#options.fetch ?? fetch
@@ -230,9 +233,7 @@ export class LlamaCppRuntime {
     while (Date.now() < deadline) {
       signal.throwIfAborted()
       if (processHasTerminated(child)) {
-        throw new Error(
-          `llama-server exited before becoming ready: ${logs.join("").trim() || processTermination(child)}`,
-        )
+        throw new Error(`llama-server exited before becoming ready: ${logs.value.trim() || processTermination(child)}`)
       }
       let response: Response | undefined
       try {
@@ -302,6 +303,11 @@ function serverArgs(model: LocalModelSpec, hardware: HardwareProbe, port: number
   ]
 }
 
+function servingKey(model: LocalModelSpec, hardware: HardwareProbe) {
+  const targetMiB = inferenceMemoryBudget(hardware).deviceHeadroomBytes / 1024 ** 2
+  return `${model.id}:${hardware.platform}:${hardware.arch}:${hardware.backend}:${targetMiB}`
+}
+
 function llamaServerEnvironment(env: NodeJS.ProcessEnv, modelCache: string) {
   const childEnv = childProcessEnvironment(env)
   for (const name of Object.keys(childEnv)) {
@@ -311,19 +317,54 @@ function llamaServerEnvironment(env: NodeJS.ProcessEnv, modelCache: string) {
   return childEnv
 }
 
-async function downloadToTemp(url: string, fetchImpl: typeof fetch, signal?: AbortSignal) {
-  const response = await fetchImpl(url, { headers: { "user-agent": "otis" }, signal })
+async function downloadToTemp(asset: LlamaCppAsset, fetchImpl: typeof fetch, signal?: AbortSignal) {
+  const response = await fetchImpl(asset.url, { headers: { "user-agent": "otis" }, signal })
   if (!response.ok || !response.body) {
     throw new Error(`Could not download llama.cpp (HTTP ${response.status}).`)
   }
+  const contentLengthHeader = response.headers.get("content-length")
+  const contentLength = contentLengthHeader === null ? undefined : Number(contentLengthHeader)
+  if (contentLength !== undefined && (!Number.isSafeInteger(contentLength) || contentLength < 0)) {
+    throw new Error("Could not download llama.cpp: the server returned an invalid content length.")
+  }
+  if (contentLength !== undefined && contentLength !== asset.size) {
+    throw new Error(`Could not download llama.cpp: expected ${asset.size} bytes but received ${contentLength}.`)
+  }
   const directory = await mkdtemp(join(tmpdir(), "otis-llama-dl-"))
   const archivePath = join(directory, "llama.tar.gz")
+  const file = await open(archivePath, "wx", 0o600)
+  const hash = createHash("sha256")
+  let received = 0
+  let closed = false
+  let complete = false
   try {
-    await writeFile(archivePath, Buffer.from(await response.arrayBuffer()))
+    const reader = response.body.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      signal?.throwIfAborted()
+      if (!value || value.byteLength === 0) continue
+      if (received + value.byteLength > asset.size) {
+        throw new Error("Could not download llama.cpp: the response exceeded the pinned artifact size.")
+      }
+      await file.writeFile(value)
+      hash.update(value)
+      received += value.byteLength
+    }
+    signal?.throwIfAborted()
+    if (received !== asset.size) {
+      throw new Error(`Could not download llama.cpp: expected ${asset.size} bytes but received ${received}.`)
+    }
+    if (hash.digest("hex") !== asset.sha256) {
+      throw new Error("Could not download llama.cpp: SHA-256 verification failed.")
+    }
+    await file.close()
+    closed = true
+    complete = true
     return { archivePath, directory }
-  } catch (error) {
-    await rm(directory, { recursive: true, force: true })
-    throw error
+  } finally {
+    if (!closed) await file.close().catch(() => undefined)
+    if (!complete) await rm(directory, { recursive: true, force: true })
   }
 }
 
@@ -348,21 +389,24 @@ async function findNamedFile(root: string, fileName: string): Promise<string | u
   return undefined
 }
 
-async function findCachedLlamaServer(binaryRoot: string, hardware: HardwareProbe) {
+async function findCachedLlamaServer(binaryDir: string, hardware: HardwareProbe, artifactSha256: string) {
+  return (await isUsableRuntimeBundle(binaryDir, hardware, artifactSha256))
+    ? join(binaryDir, "llama-server")
+    : undefined
+}
+
+async function removeUnpinnedRuntimeBundles(binaryRoot: string) {
+  let entries: Dirent[]
   try {
-    const entries = await readdir(binaryRoot, { withFileTypes: true })
-    const releases = entries
-      .filter((entry) => entry.isDirectory() && /^b\d+$/.test(entry.name))
-      .sort((left, right) => Number(right.name.slice(1)) - Number(left.name.slice(1)))
-    for (const release of releases) {
-      const bundle = join(binaryRoot, release.name)
-      if (await isUsableRuntimeBundle(bundle, hardware)) return join(bundle, "llama-server")
-    }
-    return undefined
+    entries = await readdir(binaryRoot, { withFileTypes: true })
   } catch (error) {
-    if (isNotFound(error)) return undefined
+    if (isNotFound(error)) return
     throw error
   }
+  const stale = entries.filter(
+    (entry) => entry.isDirectory() && /^b\d+$/.test(entry.name) && entry.name !== LLAMA_CPP_RELEASE_TAG,
+  )
+  await Promise.allSettled(stale.map((entry) => rm(join(binaryRoot, entry.name), { recursive: true, force: true })))
 }
 
 async function publishRuntimeBundle(
@@ -370,13 +414,14 @@ async function publishRuntimeBundle(
   binaryDir: string,
   previousDir: string,
   hardware: HardwareProbe,
+  artifactSha256: string,
 ) {
   try {
     await rename(candidateDir, binaryDir)
     return
   } catch (error) {
     // Another process may have completed the same install first.
-    if (await isUsableRuntimeBundle(binaryDir, hardware)) return
+    if (await isUsableRuntimeBundle(binaryDir, hardware, artifactSha256)) return
     if (!isDestinationExists(error)) throw error
   }
 
@@ -392,7 +437,7 @@ async function publishRuntimeBundle(
     try {
       await rename(candidateDir, binaryDir)
     } catch (error) {
-      if (!(await isUsableRuntimeBundle(binaryDir, hardware))) throw error
+      if (!(await isUsableRuntimeBundle(binaryDir, hardware, artifactSha256))) throw error
     }
   } catch (error) {
     if (displaced && !(await pathExists(binaryDir))) {
@@ -404,7 +449,7 @@ async function publishRuntimeBundle(
   }
 }
 
-async function isUsableRuntimeBundle(bundleDir: string, hardware: HardwareProbe) {
+async function isUsableRuntimeBundle(bundleDir: string, hardware: HardwareProbe, artifactSha256: string) {
   if (!(await isExecutable(join(bundleDir, "llama-server")))) return false
 
   let names: string[]
@@ -417,7 +462,7 @@ async function isUsableRuntimeBundle(bundleDir: string, hardware: HardwareProbe)
 
   try {
     const manifest = JSON.parse(await readFile(join(bundleDir, RUNTIME_MANIFEST), "utf8")) as unknown
-    return isRuntimeManifestFor(manifest, hardware)
+    return isRuntimeManifestFor(manifest, hardware, artifactSha256)
   } catch (error) {
     if (!isNotFound(error)) return false
   }
@@ -436,29 +481,37 @@ function hasRuntimeLibraries(names: readonly string[], platform: NodeJS.Platform
   )
 }
 
-async function writeRuntimeManifest(bundleDir: string, releaseTag: string, hardware: HardwareProbe) {
+async function writeRuntimeManifest(
+  bundleDir: string,
+  releaseTag: string,
+  hardware: HardwareProbe,
+  artifactSha256: string,
+) {
   await writeFile(
     join(bundleDir, RUNTIME_MANIFEST),
     `${JSON.stringify({
-      version: 1,
+      version: 2,
       releaseTag,
       platform: hardware.platform,
       arch: hardware.arch,
       backend: hardware.backend,
+      artifactSha256,
     })}\n`,
     { encoding: "utf8", mode: 0o600 },
   )
 }
 
-function isRuntimeManifestFor(value: unknown, hardware: HardwareProbe) {
+function isRuntimeManifestFor(value: unknown, hardware: HardwareProbe, artifactSha256: string) {
   if (typeof value !== "object" || value === null) return false
   const manifest = value as Record<string, unknown>
-  return (
-    manifest.version === 1 &&
+  const matchesTarget =
+    manifest.releaseTag === LLAMA_CPP_RELEASE_TAG &&
     manifest.platform === hardware.platform &&
     manifest.arch === hardware.arch &&
     manifest.backend === hardware.backend
-  )
+  if (!matchesTarget) return false
+  if (manifest.version === 1) return true
+  return manifest.version === 2 && manifest.artifactSha256 === artifactSha256
 }
 
 async function allocatePort() {
@@ -519,10 +572,6 @@ function formatBytes(bytes: number) {
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
-}
-
-function safePathSegment(value: string) {
-  return value.replace(/[^a-zA-Z0-9._-]/g, "_")
 }
 
 function isNotFound(error: unknown) {

--- a/src/inference/local-catalog.ts
+++ b/src/inference/local-catalog.ts
@@ -23,6 +23,10 @@ export type LocalModelSpec = {
   sourceModel: string
   ggufRepo: string
   ggufFile: string
+  /** Immutable Hugging Face repository commit containing `ggufFile`. */
+  ggufRevision: string
+  /** SHA-256 from the repository's Git LFS object metadata. */
+  ggufSha256: string
   quant: string
   weightBytes: number
   nativeContextLength: number
@@ -45,6 +49,8 @@ export const LOCAL_MODELS: readonly LocalModelSpec[] = [
     sourceModel: "Qwen/Qwen3.8-27B",
     ggufRepo: "ggml-org/Qwen3.8-27B-GGUF",
     ggufFile: "Qwen3.8-27B-Q4_K_M.gguf",
+    ggufRevision: "0669b98607d47046c7c2b3f801011d54a08cfccf",
+    ggufSha256: "31629f53165ab6a7dad8c9847dcfd1fdf55829dac1e6e748f4a68581b0033d34",
     quant: "Q4_K_M",
     weightBytes: 18_973_870_432,
     nativeContextLength: 262_144,
@@ -58,6 +64,8 @@ export const LOCAL_MODELS: readonly LocalModelSpec[] = [
     // Qwen's GGUF listing is not publicly readable; this is a Q4_K_M conversion of the official Instruct weights.
     ggufRepo: "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-GGUF",
     ggufFile: "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+    ggufRevision: "1f4ceb1041258b3fbfe59e1175d1321c6b41863b",
+    ggufSha256: "79ad15a5ee3caddc3f4ff0db33a14454a5a3eb503d7fa1c1e35feafc579de486",
     quant: "Q4_K_M",
     weightBytes: 18_632_186_176,
     nativeContextLength: 262_144,
@@ -70,6 +78,8 @@ export const LOCAL_MODELS: readonly LocalModelSpec[] = [
     sourceModel: "openai/gpt-oss-20b",
     ggufRepo: "ggml-org/gpt-oss-20b-GGUF",
     ggufFile: "gpt-oss-20b-MXFP4.gguf",
+    ggufRevision: "ef9b12f2ff56c69cf32153a02784e7a3c88bf524",
+    ggufSha256: "27cd6c432c7672cb812a92f611cf3ba7bbc35928262bb1e1253ff4ee6ae35901",
     quant: "MXFP4",
     weightBytes: 12_109_566_624,
     nativeContextLength: 131_072,
@@ -87,6 +97,8 @@ export const LOCAL_MODELS: readonly LocalModelSpec[] = [
     sourceModel: "google/gemma-4-26B-A4B-it",
     ggufRepo: "google/gemma-4-26B-A4B-it-qat-q4_0-gguf",
     ggufFile: "gemma-4-26B_q4_0-it.gguf",
+    ggufRevision: "d1c082be9cf3c8a514acf63b8761f4b41935842e",
+    ggufSha256: "3eca3b8f6d7baf218a7dd6bba5fb59a56ee25fe2d567b6f5f589b4f697eca51d",
     quant: "Q4_0",
     weightBytes: 14_439_363_584,
     nativeContextLength: 262_144,
@@ -104,6 +116,8 @@ export const LOCAL_MODELS: readonly LocalModelSpec[] = [
     sourceModel: "google/gemma-4-31B-it",
     ggufRepo: "google/gemma-4-31B-it-qat-q4_0-gguf",
     ggufFile: "gemma-4-31B_q4_0-it.gguf",
+    ggufRevision: "59dde24573e7e61570dba08b18a2e1fe246955ed",
+    ggufSha256: "179cfb99212709597eae5929112cfca677e1bbf566178b479ae1da0c4772874b",
     quant: "Q4_0",
     weightBytes: 17_651_001_568,
     nativeContextLength: 262_144,

--- a/src/inference/local-fit.ts
+++ b/src/inference/local-fit.ts
@@ -1,4 +1,4 @@
-import { availableInferenceMemory, type HardwareProbe } from "./hardware.js"
+import { availableModelMemory, type HardwareProbe } from "./hardware.js"
 import {
   LOCAL_CONTEXT_ALIGNMENT,
   LOCAL_MIN_CONTEXT_LENGTH,
@@ -7,7 +7,10 @@ import {
   type LocalModelSpec,
 } from "./local-catalog.js"
 
-const GRAPH_OVERHEAD_BYTES = 512 * 1024 * 1024
+// The pinned llama.cpp estimator reports roughly 1.1 GiB of compute buffers for
+// the largest-context catalog model. Keep additional margin because graph memory
+// is architecture- and backend-dependent; llama.cpp remains authoritative at load.
+const RUNTIME_OVERHEAD_BYTES = 1.5 * 1024 ** 3
 const KV_ELEMENT_BYTES = 4 // f16 key + f16 value
 
 export type LocalModelFit = {
@@ -19,7 +22,7 @@ export type LocalModelFit = {
 }
 
 export function fitLocalModel(model: LocalModelSpec, hardware: HardwareProbe): LocalModelFit {
-  const memoryAvailableBytes = availableInferenceMemory(hardware)
+  const memoryAvailableBytes = availableModelMemory(hardware)
   return fitLocalModelWithinMemory(model, memoryAvailableBytes)
 }
 
@@ -73,7 +76,7 @@ export function memoryRequiredFor(model: LocalModelSpec, contextLength: number) 
   if (!Number.isSafeInteger(contextLength) || contextLength <= 0) {
     throw new Error("Context length must be a positive integer.")
   }
-  return model.weightBytes + kvCacheBytes(model.attention, contextLength) + GRAPH_OVERHEAD_BYTES
+  return model.weightBytes + kvCacheBytes(model.attention, contextLength) + RUNTIME_OVERHEAD_BYTES
 }
 
 export function kvCacheBytes(attention: LocalAttentionSpec, contextLength: number) {

--- a/src/inference/picker-catalog.ts
+++ b/src/inference/picker-catalog.ts
@@ -1,14 +1,9 @@
 import { listToolCapableModels } from "./catalog.js"
 import { isLocalGgufDownloaded } from "./gguf-cache.js"
-import { currentlyAvailableInferenceMemory, detectHardware, type HardwareProbe } from "./hardware.js"
+import { detectHardware, type HardwareProbe } from "./hardware.js"
+import { supportsLlamaCppTarget, unsupportedLlamaCppTargetMessage } from "./llama-binary.js"
 import { LOCAL_MODELS } from "./local-catalog.js"
-import {
-  fitLocalModel,
-  fitLocalModelWithinMemory,
-  formatMemoryLabel,
-  type LocalModelFit,
-  memoryRequiredFor,
-} from "./local-fit.js"
+import { fitLocalModel, formatMemoryLabel, type LocalModelFit, memoryRequiredFor } from "./local-fit.js"
 import { matchesFireworksModel } from "./serving-path.js"
 import type { FireworksModel, LocalCatalogModel } from "./types.js"
 
@@ -20,13 +15,18 @@ export type ModelPickerHeader = {
   displayName: string
 }
 
+export type ModelPickerStatus = {
+  label: string
+  kind: "progress" | "error"
+}
+
 export type LocalPickerChoice = LocalCatalogModel & {
   kind: "model"
   available: boolean
   availabilityLabel: string
   loadedContextLength?: number
   downloaded: boolean
-  statusLabel?: string
+  status?: ModelPickerStatus
   active: boolean
 }
 
@@ -43,7 +43,7 @@ export type ListModelPickerOptions = {
   currentModel?: string
   hardware?: HardwareProbe
   dataDirectory?: string
-  loadStatus?: { modelId: string; label: string }
+  loadStatus?: { modelId: string; status: ModelPickerStatus }
   loadedLocalModel?: { model: string; contextLength: number }
   detect?: typeof detectHardware
   listFireworks?: typeof listToolCapableModels
@@ -52,13 +52,12 @@ export type ListModelPickerOptions = {
 
 export async function listModelPickerItems(options: ListModelPickerOptions = {}): Promise<ModelPickerItem[]> {
   const hardware = options.hardware ?? (await (options.detect ?? detectHardware)())
-  const currentInferenceMemory =
-    hardware.gpuMemoryFreeBytes !== undefined ? currentlyAvailableInferenceMemory(hardware) : undefined
+  const localUnavailableReason = supportsLlamaCppTarget(hardware)
+    ? undefined
+    : unsupportedLlamaCppTargetMessage(hardware)
   const localItems = await Promise.all(
     LOCAL_MODELS.map(async (model) => {
       const fit = fitLocalModel(model, hardware)
-      const currentFit =
-        currentInferenceMemory === undefined ? fit : fitLocalModelWithinMemory(model, currentInferenceMemory)
       const loadedContextLength =
         options.currentModel === model.id && options.loadedLocalModel?.model === model.id
           ? options.loadedLocalModel.contextLength
@@ -67,7 +66,7 @@ export async function listModelPickerItems(options: ListModelPickerOptions = {})
       return toLocalPickerChoice(
         model,
         fit,
-        currentFit,
+        localUnavailableReason,
         loadedContextLength,
         options.currentModel,
         downloaded,
@@ -113,7 +112,7 @@ export function toLocalCatalogModel(item: LocalPickerChoice): LocalCatalogModel 
 function fireworksSection(models: readonly FireworksModel[], currentModel?: string): ModelPickerItem[] {
   if (models.length === 0) return []
   return [
-    { kind: "header", id: "header-fireworks", displayName: "Fireworks" },
+    { kind: "header", id: "header-hosted", displayName: "Hosted" },
     ...models.map((model) => toFireworksPickerChoice(model, currentModel)),
   ]
 }
@@ -121,26 +120,24 @@ function fireworksSection(models: readonly FireworksModel[], currentModel?: stri
 function toLocalPickerChoice(
   model: (typeof LOCAL_MODELS)[number],
   fit: ReturnType<typeof fitLocalModel>,
-  currentFit: LocalModelFit,
+  localUnavailableReason: string | undefined,
   loadedContextLength: number | undefined,
   currentModel: string | undefined,
   downloaded: boolean,
-  loadStatus?: { modelId: string; label: string },
+  loadStatus?: { modelId: string; status: ModelPickerStatus },
 ): LocalPickerChoice {
   return {
     kind: "model",
     provider: "local",
     id: model.id,
     displayName: model.displayName,
-    contextLength:
-      loadedContextLength ??
-      (currentFit.available ? currentFit.contextLength : fit.available ? fit.contextLength : model.nativeContextLength),
+    contextLength: loadedContextLength ?? (fit.available ? fit.contextLength : model.nativeContextLength),
     supportsImageInput: model.supportsImageInput,
-    available: fit.available,
-    availabilityLabel: localAvailabilityLabel(model, fit, currentFit, loadedContextLength),
+    available: localUnavailableReason === undefined && fit.available,
+    availabilityLabel: localAvailabilityLabel(model, fit, localUnavailableReason, loadedContextLength),
     ...(loadedContextLength === undefined ? {} : { loadedContextLength }),
     downloaded,
-    statusLabel: loadStatus?.modelId === model.id ? loadStatus.label : undefined,
+    status: loadStatus?.modelId === model.id ? loadStatus.status : undefined,
     active: currentModel === model.id,
   }
 }
@@ -148,15 +145,15 @@ function toLocalPickerChoice(
 function localAvailabilityLabel(
   model: (typeof LOCAL_MODELS)[number],
   fit: LocalModelFit,
-  currentFit: LocalModelFit,
+  localUnavailableReason: string | undefined,
   loadedContextLength: number | undefined,
 ) {
+  if (localUnavailableReason) return localUnavailableReason
   if (loadedContextLength !== undefined) {
     return `${formatContextWindow(loadedContextLength)} loaded · ${model.quant} · ${formatMemoryLabel(memoryRequiredFor(model, loadedContextLength))}`
   }
   if (!fit.available) return `Needs ${formatMemoryLabel(fit.memoryRequiredBytes)}`
-  const recommendation = currentFit.available ? currentFit : fit
-  return `Up to ${formatContextWindow(recommendation.contextLength)} · ${model.quant} · ${formatMemoryLabel(recommendation.memoryRequiredBytes)}`
+  return `Est. ${formatContextWindow(fit.contextLength)} · ${model.quant} · ${formatMemoryLabel(fit.memoryRequiredBytes)}`
 }
 
 export function toFireworksPickerChoice(model: FireworksModel, currentModel?: string): FireworksPickerChoice {

--- a/src/inference/serving-path.ts
+++ b/src/inference/serving-path.ts
@@ -14,6 +14,11 @@ export function baseModelIdForFastServingPath(fastId: string) {
   return `accounts/fireworks/models/${slug.slice(0, -"-fast".length)}`
 }
 
+export function baseFireworksModelId(modelId: string) {
+  const resource = normalizedModelResource(modelId)
+  return baseModelIdForFastServingPath(resource) ?? resource
+}
+
 export function fireworksServiceTier(modelId: string) {
   return isFastFireworksModel(modelId) ? undefined : "priority"
 }
@@ -27,8 +32,8 @@ export function findFireworksModel(models: readonly FireworksModel[], modelId: s
 }
 
 /** Fast serving is opt-in. Keep an already-Fast model ID; otherwise require an explicit preference. */
-export function useFastServingPath(modelId: string | undefined, fastMode?: boolean) {
-  return Boolean(modelId && isFastFireworksModel(modelId)) || fastMode === true
+export function useFastServingPath(modelId: string | undefined, fast?: boolean) {
+  return Boolean(modelId && isFastFireworksModel(modelId)) || fast === true
 }
 
 export function fireworksServingModel(model: FireworksModel, fast: boolean): FireworksModel {

--- a/src/local/settings.ts
+++ b/src/local/settings.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { isLocalModelId } from "../inference/local-catalog.js"
+import { baseFireworksModelId, isFastFireworksModel } from "../inference/serving-path.js"
 import type { CatalogModel, FireworksModel, ModelProvider } from "../inference/types.js"
 import { type PermissionConfig, parsePermissionConfig } from "../permissions/policy.js"
 import { localConfigDirectory } from "./paths.js"
@@ -15,7 +16,7 @@ export type LocalSettings = {
   modelProvider?: ModelProvider
   theme?: ThemeName
   thinkingVisible?: boolean
-  fastMode?: boolean
+  fastServingModels?: string[]
   modelFastId?: string
   permissions?: PermissionConfig
 }
@@ -48,7 +49,9 @@ type SettingsFile = {
   modelProvider?: ModelProvider
   theme?: ThemeName
   thinkingVisible?: boolean
+  /** Read only to migrate the released global preference to the selected model. */
   fastMode?: boolean
+  fastServingModels?: string[]
   modelFastId?: string
   permissions?: PermissionConfig
 }
@@ -57,6 +60,7 @@ export async function loadLocalSettings(options: SettingsFileOptions = {}): Prom
   const env = options.env ?? process.env
   const saved = await readSettingsFile(options)
   const envFireworksApiKey = clean(env.FIREWORKS_API_KEY)
+  const fastServingModels = saved ? migratedFastServingModels(saved) : []
 
   return {
     fireworksApiKey: envFireworksApiKey ?? saved?.fireworksApiKey,
@@ -69,7 +73,7 @@ export async function loadLocalSettings(options: SettingsFileOptions = {}): Prom
     ...(saved?.modelSupportsImageInput !== undefined ? { modelSupportsImageInput: saved.modelSupportsImageInput } : {}),
     ...(saved?.theme ? { theme: saved.theme } : {}),
     ...(saved?.thinkingVisible !== undefined ? { thinkingVisible: saved.thinkingVisible } : {}),
-    ...(saved?.fastMode !== undefined ? { fastMode: saved.fastMode } : {}),
+    ...(fastServingModels.length > 0 ? { fastServingModels } : {}),
     ...(saved?.modelFastId ? { modelFastId: saved.modelFastId } : {}),
     ...(saved?.permissions ? { permissions: saved.permissions } : {}),
   }
@@ -81,6 +85,11 @@ export async function saveFireworksSetup(apiKey: string, model: FireworksModel, 
     withSelectedModel({ ...saved, fireworksApiKey: required(apiKey, "Fireworks API key") }, model),
     options,
   )
+}
+
+export async function saveFireworksApiKey(apiKey: string, options: SettingsFileOptions = {}) {
+  const saved = (await readSettingsFile(options)) ?? { version: 1 }
+  await writeSettingsFile({ ...saved, fireworksApiKey: required(apiKey, "Fireworks API key") }, options)
 }
 
 export async function saveSelectedModel(model: CatalogModel, options: SettingsFileOptions = {}) {
@@ -103,9 +112,18 @@ export async function saveThinkingVisible(visible: boolean, options: SettingsFil
   await writeSettingsFile({ ...saved, thinkingVisible: visible }, options)
 }
 
-export async function saveFastMode(fast: boolean, options: SettingsFileOptions = {}) {
+export async function saveFastServingSelection(
+  model: FireworksModel,
+  fast: boolean,
+  options: SettingsFileOptions = {},
+) {
   const saved = (await readSettingsFile(options)) ?? { version: 1 }
-  await writeSettingsFile({ ...saved, fastMode: fast }, options)
+  const selected = withSelectedModel(saved, model)
+  const fastServingModels = new Set(selected.fastServingModels ?? [])
+  const modelId = baseFireworksModelId(model.id)
+  if (fast) fastServingModels.add(modelId)
+  else fastServingModels.delete(modelId)
+  await writeSettingsFile({ ...selected, fastServingModels: [...fastServingModels].sort() }, options)
 }
 
 function defaultSettingsFile() {
@@ -157,6 +175,7 @@ function parseSettingsFile(value: unknown): SettingsFile {
   const theme = optionalTheme(value.theme)
   const thinkingVisible = optionalBoolean(value.thinkingVisible, "thinkingVisible")
   const fastMode = optionalBoolean(value.fastMode, "fastMode")
+  const fastServingModels = optionalStringArray(value.fastServingModels, "fastServingModels")
   const modelFastId = optionalString(value.modelFastId, "modelFastId")
   const modelProvider = optionalModelProvider(value.modelProvider)
   const permissions =
@@ -174,6 +193,7 @@ function parseSettingsFile(value: unknown): SettingsFile {
     ...(theme ? { theme } : {}),
     ...(thinkingVisible !== undefined ? { thinkingVisible } : {}),
     ...(fastMode !== undefined ? { fastMode } : {}),
+    ...(fastServingModels !== undefined ? { fastServingModels } : {}),
     ...(modelFastId ? { modelFastId } : {}),
     ...(permissions ? { permissions } : {}),
   }
@@ -182,6 +202,7 @@ function parseSettingsFile(value: unknown): SettingsFile {
 function withSelectedModel(settings: SettingsFile, model: CatalogModel): SettingsFile {
   const contextLength =
     model.contextLength === undefined ? undefined : positiveInteger(model.contextLength, "model context length")
+  const fastServingModels = migratedFastServingModels(settings)
   return {
     version: 1,
     ...(settings.fireworksApiKey ? { fireworksApiKey: settings.fireworksApiKey } : {}),
@@ -193,20 +214,35 @@ function withSelectedModel(settings: SettingsFile, model: CatalogModel): Setting
     ...(model.provider === "fireworks" && model.fastId ? { modelFastId: model.fastId } : {}),
     ...(settings.theme ? { theme: settings.theme } : {}),
     ...(settings.thinkingVisible !== undefined ? { thinkingVisible: settings.thinkingVisible } : {}),
-    ...(settings.fastMode !== undefined ? { fastMode: settings.fastMode } : {}),
+    ...(shouldPersistFastServingModels(settings, fastServingModels) ? { fastServingModels } : {}),
     ...(settings.permissions ? { permissions: settings.permissions } : {}),
   }
 }
 
 function withoutSelectedModel(settings: SettingsFile): SettingsFile {
+  const fastServingModels = migratedFastServingModels(settings)
   return {
     version: 1,
     ...(settings.fireworksApiKey ? { fireworksApiKey: settings.fireworksApiKey } : {}),
     ...(settings.theme ? { theme: settings.theme } : {}),
     ...(settings.thinkingVisible !== undefined ? { thinkingVisible: settings.thinkingVisible } : {}),
-    ...(settings.fastMode !== undefined ? { fastMode: settings.fastMode } : {}),
+    ...(shouldPersistFastServingModels(settings, fastServingModels) ? { fastServingModels } : {}),
     ...(settings.permissions ? { permissions: settings.permissions } : {}),
   }
+}
+
+function migratedFastServingModels(settings: SettingsFile) {
+  if (settings.fastServingModels !== undefined) {
+    return [...new Set(settings.fastServingModels.map(baseFireworksModelId))].sort()
+  }
+  if (!settings.model || (settings.modelProvider ?? inferModelProvider(settings.model)) !== "fireworks") return []
+  return settings.fastMode === true || isFastFireworksModel(settings.model)
+    ? [baseFireworksModelId(settings.model)]
+    : []
+}
+
+function shouldPersistFastServingModels(settings: SettingsFile, models: string[]) {
+  return models.length > 0 || settings.fastServingModels !== undefined || settings.fastMode !== undefined
 }
 
 function inferModelProvider(modelId: string | undefined): ModelProvider | undefined {
@@ -240,6 +276,12 @@ function optionalString(value: unknown, name: string) {
   if (value === undefined) return undefined
   if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid Otis config: ${name} must be a string.`)
   return value.trim()
+}
+
+function optionalStringArray(value: unknown, name: string) {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) throw new Error(`Invalid Otis config: ${name} must be an array of strings.`)
+  return [...new Set(value.map((item) => optionalString(item, name) as string))]
 }
 
 function required(value: string, label: string) {

--- a/tests/cli/chat-ui-input.test.ts
+++ b/tests/cli/chat-ui-input.test.ts
@@ -1,5 +1,13 @@
-import type { InputRenderable, TextareaRenderable, TextRenderable } from "@opentui/core"
+import {
+  type BoxRenderable,
+  type InputRenderable,
+  RGBA,
+  type TextareaRenderable,
+  type TextRenderable,
+} from "@opentui/core"
 import { describe, expect, it, vi } from "vitest"
+import { colors } from "../../src/cli/theme.js"
+import { COLOR_PULSE_PERIOD_MS, selectionOutline } from "../../src/cli/ui/color-pulse.js"
 import { CHAT_INPUT_HINT } from "../../src/cli/ui/format.js"
 import { toFireworksPickerChoice } from "../../src/inference/picker-catalog.js"
 import { fireworksModel } from "../../src/inference/types.js"
@@ -21,7 +29,7 @@ describe("chat UI input", () => {
       commands: [
         { name: "/new", description: "Start a new session" },
         { name: "/history", description: "Open session history" },
-        { name: "/debug", description: "Toggle debug messages" },
+        { name: "/settings", description: "Configure Otis" },
         { name: "/exit", description: "Exit Otis" },
       ],
       onSubmit,
@@ -46,12 +54,12 @@ describe("chat UI input", () => {
       {
         name: "gpt-oss 20B",
         description: "MXFP4 · 12 GB",
-        submission: "/delete-model openai/gpt-oss-20b",
+        submission: "/settings delete-model openai/gpt-oss-20b",
       },
       {
         name: "Qwen3.8 27B",
         description: "Q4_K_M · 17 GB",
-        submission: "/delete-model Qwen/Qwen3.8-27B",
+        submission: "/settings delete-model Qwen/Qwen3.8-27B",
       },
     ])
 
@@ -60,7 +68,90 @@ describe("chat UI input", () => {
     expect(harness.find("model-panel")).toBeUndefined()
     harness.press("down")
     harness.press("return")
-    expect(onSubmit).toHaveBeenCalledWith("/delete-model Qwen/Qwen3.8-27B")
+    expect(onSubmit).toHaveBeenCalledWith("/settings delete-model Qwen/Qwen3.8-27B")
+    expect(harness.find("command-menu")).toBeUndefined()
+  })
+
+  it("returns from a nested command submenu to its parent on Escape", async () => {
+    const harness = await setup()
+    const parent = [
+      { name: "Hosted inference", description: "Add API key", submission: "/settings hosted" },
+      { name: "Delete local model", description: "Choose a downloaded model", submission: "/settings delete-model" },
+      { name: "Debug mode", description: "Off", submission: "/settings debug" },
+    ]
+    const showParent = vi.fn(() => harness.ui.showCommandSubmenu(parent))
+    harness.ui.showCommandSubmenu(
+      [
+        {
+          name: "gpt-oss 20B",
+          description: "MXFP4 · 12 GB",
+          submission: "/settings delete-model openai/gpt-oss-20b",
+        },
+      ],
+      { onBack: showParent },
+    )
+
+    harness.press("escape")
+
+    expect(showParent).toHaveBeenCalledOnce()
+    expect(harness.text("command-row-0")).toBe("› Hosted inference")
+    expect(harness.text("command-row-1")).toBe("  Delete local model")
+    expect(harness.text("command-row-2")).toBe("  Debug mode")
+
+    harness.press("escape")
+    expect(harness.find("command-menu")).toBeUndefined()
+  })
+
+  it("opens the settings submenu from the slash menu", async () => {
+    let openSettings = () => {}
+    const onSubmit = vi.fn((value: string) => {
+      if (value === "/settings") openSettings()
+    })
+    const harness = await setup({
+      commands: [
+        { name: "/model", description: "Choose a model" },
+        { name: "/settings", description: "Configure Otis" },
+      ],
+      onSubmit,
+    })
+    openSettings = () => {
+      harness.ui.clearInput()
+      harness.ui.showCommandSubmenu(
+        [
+          {
+            name: "Hosted inference",
+            description: "Add API key",
+            submission: "/settings hosted",
+          },
+          {
+            name: "Debug mode",
+            description: "Off",
+            submission: "/settings debug",
+          },
+        ],
+        { onBack: () => harness.ui.showSlashCommandMenu() },
+      )
+      harness.ui.focusInput()
+    }
+    harness.setChatInput("/")
+    harness.press("down")
+    harness.press("return")
+
+    // The native textarea may deliver the content-change event from clearInput
+    // after the submenu has already been mounted.
+    harness.get<TextareaRenderable>("otis-input").onContentChange?.({} as never)
+
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expect(onSubmit).toHaveBeenCalledWith("/settings")
+    expect(harness.text("command-row-0")).toBe("› Hosted inference")
+    expect(harness.text("command-row-1")).toBe("  Debug mode")
+
+    harness.press("escape")
+    expect(harness.get<TextareaRenderable>("otis-input").plainText).toBe("/")
+    expect(harness.text("command-row-0")).toBe("› /model")
+    expect(harness.text("command-row-1")).toBe("  /settings")
+
+    harness.press("escape")
     expect(harness.find("command-menu")).toBeUndefined()
   })
 
@@ -200,20 +291,91 @@ describe("chat UI input", () => {
     expect(harness.childIds("chat-body")).toEqual(["messages"])
   })
 
-  it("starts unconfigured and submits a Fireworks API key", async () => {
+  it("chooses local or hosted inference with arrow keys before accepting an API key", async () => {
     const onSetup = vi.fn()
+    const onSetupInferenceChoice = vi.fn()
     const onSetupSubmit = vi.fn()
-    const harness = await setup({ configured: false, onSetup, onSetupSubmit })
+    const harness = await setup({ configured: false, onSetup, onSetupInferenceChoice, onSetupSubmit })
 
     expect(harness.childIds("input-area")).toEqual(["setup-box"])
     expect(harness.childIds("setup-box")).toEqual(["setup-why", "setup-local", "setup-button-box"])
     expect(harness.text("setup-button")).toContain("Set up Otis")
-    expect(harness.text("setup-why")).toBe("Otis uses Fireworks as its inference provider.")
-    expect(harness.text("setup-local")).toBe("Your key and sessions stay on this machine.")
+    expect(harness.text("setup-why")).toBe("Your terminal agent, powered by open models.")
+    expect(harness.text("setup-local")).toBe("Inspect files, edit code, run commands, and search the web.")
+    await harness.renderOnce()
+    expect(harness.get<BoxRenderable>("welcome-panel").width).toBe(72)
 
     harness.press("return")
     expect(onSetup).toHaveBeenCalledOnce()
 
+    harness.ui.showSetupInferenceChoice()
+    expect(harness.childIds("input-area")).toEqual(["setup-choice"])
+    expect(harness.childIds("setup-choice")).toEqual([
+      "setup-choice-heading",
+      "setup-choice-cards",
+      "setup-choice-hint",
+    ])
+    expect(harness.text("setup-choice-heading")).toBe("Choose how Otis runs models")
+    expect(harness.find("setup-choice-subheading")).toBeUndefined()
+    expect(harness.childIds("setup-choice-cards")).toEqual(["setup-choice-local", "setup-choice-hosted"])
+    await harness.renderOnce()
+    expect(harness.get<BoxRenderable>("welcome-panel").width).toBe(84)
+    expect(
+      harness
+        .captureCharFrame()
+        .split("\n")
+        .some((line) => line.includes("Local inference") && line.includes("Hosted inference")),
+    ).toBe(true)
+    expect(harness.text("setup-choice-local-title")).toBe("Local inference")
+    expect(harness.text("setup-choice-local-label")).toBe("Runs on your machine")
+    expect(harness.text("setup-choice-local-description")).toBe("Run open models on your own hardware.")
+    expect(harness.text("setup-choice-local-detail-0")).toBe("Recommended hardware:")
+    expect(harness.text("setup-choice-local-detail-1")).toBe("Apple silicon · 24 GB+ unified memory")
+    expect(harness.text("setup-choice-local-detail-2")).toBe("Linux · 24 GB+ RAM")
+    expect(harness.text("setup-choice-local-detail-3")).toBe("Vulkan GPU · 16 GB+ VRAM")
+    expect(harness.text("setup-choice-local-detail-4")).toBe("12–19 GB disk per model")
+    expect(harness.text("setup-choice-hosted-label")).toBe("Powered by Fireworks")
+    expect(harness.text("setup-choice-hosted-description")).toBe(
+      "Fast remote inference with no local hardware requirements.",
+    )
+    expect(harness.text("setup-choice-hosted-detail-0")).toBe("Zero Data Retention by default.")
+    expect(harness.text("setup-choice-hosted-detail-1")).toBe("Uses your own Fireworks API key.")
+    expect(harness.text("setup-choice-hosted-detail-2")).toBe("Configure it anytime in Settings.")
+    expect(harness.text("setup-choice-hint")).toBe("[←→] move · [enter] select")
+
+    const localCard = harness.get<BoxRenderable>("setup-choice-local")
+    const hostedCard = harness.get<BoxRenderable>("setup-choice-hosted")
+    const localTitle = harness.get<TextRenderable>("setup-choice-local-title")
+    const hostedTitle = harness.get<TextRenderable>("setup-choice-hosted-title")
+    expect(localCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(false)
+    expect(hostedCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(true)
+    expect(Math.abs(localTitle.x + localTitle.width / 2 - (localCard.x + localCard.width / 2))).toBeLessThanOrEqual(1)
+    expect(Math.abs(hostedTitle.x + hostedTitle.width / 2 - (hostedCard.x + hostedCard.width / 2))).toBeLessThanOrEqual(
+      1,
+    )
+
+    harness.press("return")
+    expect(onSetupInferenceChoice).toHaveBeenLastCalledWith("local")
+    harness.ui.showSetupInferenceChoice()
+    harness.press("right")
+    expect(harness.text("setup-choice-hosted-title")).toBe("Hosted inference")
+    expect(hostedCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(false)
+    expect(localCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(true)
+    harness.press("left")
+    expect(harness.text("setup-choice-local-title")).toBe("Local inference")
+    harness.press("right")
+    harness.press("return")
+    expect(onSetupInferenceChoice).toHaveBeenLastCalledWith("hosted")
+
+    harness.ui.showSetupInput()
+    await harness.renderOnce()
+    expect(harness.get<BoxRenderable>("welcome-panel").width).toBe(72)
+    const setupInput = harness.get<InputRenderable>("setup-input")
+    expect(setupInput.focused).toBe(true)
+    harness.press("escape")
+    expect(setupInput.focused).toBe(false)
+    expect(harness.childIds("input-area")).toEqual(["setup-choice"])
+    expect(harness.text("setup-choice-hosted-title")).toBe("Hosted inference")
     harness.ui.showSetupInput()
     expect(harness.text("setup-input-label")).toBe("Fireworks API key")
     expect(harness.childIds("setup-form")).toEqual(["setup-input-box", "setup-continue-box"])
@@ -242,6 +404,24 @@ describe("chat UI input", () => {
     expect(harness.childIds("chat-body")).toEqual(["model-panel", "messages"])
   })
 
+  it("selects hosted inference up front when local inference is unsupported", async () => {
+    const onSetupInferenceChoice = vi.fn()
+    const reason = "Local inference is not supported on win32/x64."
+    const harness = await setup({
+      configured: false,
+      localInferenceUnavailableReason: reason,
+      onSetupInferenceChoice,
+    })
+
+    harness.ui.showSetupInferenceChoice()
+    expect(harness.text("setup-choice-message")).toBe(reason)
+    harness.press("left")
+    harness.press("return")
+
+    expect(onSetupInferenceChoice).toHaveBeenCalledOnce()
+    expect(onSetupInferenceChoice).toHaveBeenCalledWith("hosted")
+  })
+
   it("shows API keys in the input and clears them after an error", async () => {
     const onSetupSubmit = vi.fn()
     const harness = await setup({ configured: false, onSetupSubmit })
@@ -250,7 +430,7 @@ describe("chat UI input", () => {
     await harness.typeText("first-secret")
     expect(harness.get<InputRenderable>("setup-input").plainText).toBe("first-secret")
 
-    harness.ui.showSetupError("Try again")
+    harness.ui.showSetupError("Try again", "choice")
     expect(harness.get<InputRenderable>("setup-input").plainText).toBe("")
     expect(harness.childIds("setup-form")).toEqual(["setup-input-box", "setup-message", "setup-continue-box"])
     expect(harness.text("setup-message")).toBe("Try again")
@@ -259,6 +439,54 @@ describe("chat UI input", () => {
 
     expect(onSetupSubmit).toHaveBeenCalledWith("second-secret")
     expect(onSetupSubmit).not.toHaveBeenCalledWith("first-secret")
+  })
+
+  it("keeps both inference choices readable at 80 columns", async () => {
+    const harness = await setup({ configured: false })
+    harness.resize(80, 30)
+    harness.ui.showSetupInferenceChoice()
+    await harness.renderOnce()
+
+    const frame = harness.captureCharFrame()
+    expect(frame).toContain("____  _______________")
+    expect(
+      frame.split("\n").some((line) => line.includes("Local inference") && line.includes("Hosted inference")),
+    ).toBe(true)
+    expect(frame).toContain("Runs on your machine")
+    expect(frame).toContain("Powered by Fireworks")
+    expect(frame).toContain("[←→] move · [enter] select")
+  })
+
+  it("uses the model picker pulse for the selected inference card", async () => {
+    vi.useFakeTimers()
+    const harness = await setup({ configured: false })
+    harness.ui.showSetupInferenceChoice()
+
+    const localCard = harness.get<BoxRenderable>("setup-choice-local")
+    const hostedCard = harness.get<BoxRenderable>("setup-choice-hosted")
+    expect(localCard.borderColor.equals(RGBA.fromHex(selectionOutline(0)))).toBe(true)
+    expect(hostedCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(true)
+
+    vi.advanceTimersByTime(COLOR_PULSE_PERIOD_MS / 2)
+    expect(localCard.borderColor.equals(RGBA.fromHex(colors.accent))).toBe(true)
+
+    harness.press("right")
+    expect(localCard.borderColor.equals(RGBA.fromHex(colors.border))).toBe(true)
+    expect(hostedCard.borderColor.equals(RGBA.fromHex(colors.accent))).toBe(true)
+  })
+
+  it("returns to the configured input when hosted settings are cancelled", async () => {
+    const harness = await setup({ configured: true })
+
+    harness.ui.showSetupInput("", "configured")
+    const setupInput = harness.get<InputRenderable>("setup-input")
+    expect(setupInput.focused).toBe(true)
+    expect(harness.childIds("input-area")).toEqual(["setup-form"])
+
+    harness.press("escape")
+    expect(setupInput.focused).toBe(false)
+    expect(harness.get<TextareaRenderable>("otis-input").focused).toBe(true)
+    expect(harness.childIds("input-area")).toEqual(["input-box"])
   })
 
   it("submits multiline chat input and clears it", async () => {

--- a/tests/cli/chat-ui-rendering.test.ts
+++ b/tests/cli/chat-ui-rendering.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it, vi } from "vitest"
 import { colors, selectTheme } from "../../src/cli/theme.js"
 import { TranscriptStore } from "../../src/cli/transcript.js"
 import { COLOR_PULSE_PERIOD_MS, TEXT_SHIMMER_PERIOD_MS } from "../../src/cli/ui/color-pulse.js"
-import { LOCAL_LOADING_LABEL } from "../../src/cli/ui/format.js"
+import { LOCAL_DOWNLOADING_LABEL, LOCAL_LOADING_LABEL } from "../../src/cli/ui/format.js"
 import { toFireworksPickerChoice } from "../../src/inference/picker-catalog.js"
 import { fireworksModel } from "../../src/inference/types.js"
 import { useChatHarness } from "./support/chat-ui-harness.js"
@@ -448,7 +448,7 @@ describe("chat UI rendering", () => {
     expect(harness.get<BoxRenderable>("model-panel").border).toBe(false)
   })
 
-  it("lists local models above Fireworks and greys out models that will not fit", async () => {
+  it("lists local models above hosted models and greys out models that will not fit", async () => {
     const onSelectModel = vi.fn()
     const harness = await setup({ onSelectModel })
     const unavailable = {
@@ -475,7 +475,7 @@ describe("chat UI rendering", () => {
     harness.ui.showModelPicker([
       { kind: "header", id: "header-local", displayName: "Local" },
       unavailable,
-      { kind: "header", id: "header-fireworks", displayName: "Fireworks" },
+      { kind: "header", id: "header-hosted", displayName: "Hosted" },
       fireworks,
     ])
 
@@ -483,7 +483,7 @@ describe("chat UI rendering", () => {
     expect(harness.text("model-row-1")).toBe("  Qwen3.8 27B  Downloaded")
     expect(harness.text("model-row-1-meta")).toBe("  Needs 19 GB · Text")
     expect(harness.get<TextRenderable>("model-row-1").fg.equals(RGBA.fromHex(colors.muted))).toBe(true)
-    expect(harness.text("model-row-2")).toBe("FIREWORKS")
+    expect(harness.text("model-row-2")).toBe("HOSTED")
     expect(harness.text("model-row-3")).toBe("› Alpha")
 
     harness.press("return")
@@ -517,15 +517,18 @@ describe("chat UI rendering", () => {
     expect(downloaded?.fg?.equals(RGBA.fromHex(colors.muted))).toBe(true)
     expect(harness.text("model-row-1-meta")).toBe("  128K loaded · MXFP4 · 16 GB · Text")
 
-    harness.ui.setModelPickerStatus(local.id, "47%")
-    expect(harness.text("model-row-1")).toBe("› gpt-oss 20B  47%")
+    harness.ui.setModelPickerStatus(local.id, { label: "Downloading 47%", kind: "progress" })
+    expect(harness.text("model-row-1")).toBe("› gpt-oss 20B  Downloading 47%")
     expect(harness.text("model-row-1-meta")).toBe("  128K loaded · MXFP4 · 16 GB · Text")
 
-    harness.ui.setModelPickerStatus(local.id, LOCAL_LOADING_LABEL)
+    harness.ui.setModelPickerStatus(local.id, { label: LOCAL_LOADING_LABEL, kind: "progress" })
     expect(harness.text("model-row-1")).toBe("› gpt-oss 20B  Loading")
   })
 
-  it("shimmers Loading while a local model is starting", async () => {
+  it.each([
+    `${LOCAL_DOWNLOADING_LABEL} 47%`,
+    LOCAL_LOADING_LABEL,
+  ])("shimmers %s for local model progress", async (label) => {
     const harness = await setup()
     vi.useFakeTimers()
     const local = {
@@ -543,14 +546,14 @@ describe("chat UI rendering", () => {
     }
 
     harness.ui.showModelPicker([{ kind: "header", id: "header-local", displayName: "Local" }, local])
-    harness.ui.setModelPickerStatus(local.id, LOCAL_LOADING_LABEL)
+    harness.ui.setModelPickerStatus(local.id, { label, kind: "progress" })
 
-    const first = loadingLetterColors(harness.get<TextRenderable>("model-row-1"))
-    expect(first.map((letter) => letter.text).join("")).toBe("Loading")
+    const first = statusLetterColors(harness.get<TextRenderable>("model-row-1"), label)
+    expect(first.map((letter) => letter.text).join("")).toBe(label)
     expect(new Set(first.map((letter) => letter.color)).size).toBeGreaterThan(1)
 
     vi.advanceTimersByTime(TEXT_SHIMMER_PERIOD_MS / 2)
-    const later = loadingLetterColors(harness.get<TextRenderable>("model-row-1"))
+    const later = statusLetterColors(harness.get<TextRenderable>("model-row-1"), label)
     expect(later.map((letter) => letter.color)).not.toEqual(first.map((letter) => letter.color))
   })
 
@@ -564,7 +567,7 @@ describe("chat UI rendering", () => {
       contextLength: 131_072,
       supportsImageInput: false,
       available: true,
-      availabilityLabel: "Up to 128K · MXFP4 · 16 GB",
+      availabilityLabel: "Est. 128K · MXFP4 · 16 GB",
       downloaded: false,
       active: true,
     }
@@ -579,7 +582,7 @@ describe("chat UI rendering", () => {
     harness.ui.showModelPicker([
       { kind: "header", id: "header-local", displayName: "Local" },
       local,
-      { kind: "header", id: "header-fireworks", displayName: "Fireworks" },
+      { kind: "header", id: "header-hosted", displayName: "Hosted" },
       ...fireworks,
     ])
     await harness.renderOnce()
@@ -602,8 +605,8 @@ function fireworksRow(fields: Parameters<typeof fireworksModel>[0], active = fal
   return toFireworksPickerChoice(fireworksModel(fields), active ? fields.id : undefined)
 }
 
-function loadingLetterColors(row: TextRenderable) {
-  const letters = row.chunks.slice(-LOCAL_LOADING_LABEL.length)
+function statusLetterColors(row: TextRenderable, label: string) {
+  const letters = row.chunks.slice(-label.length)
   return letters.map((chunk) => ({
     text: chunk.text,
     color: chunk.fg ? chunk.fg.toInts().join(",") : "",

--- a/tests/cli/chat-ui-status.test.ts
+++ b/tests/cli/chat-ui-status.test.ts
@@ -92,6 +92,26 @@ describe("chat UI status and prompts", () => {
     expect(harness.text("welcome-stat-value-3")).toBe("7M")
   })
 
+  it("keeps the slash menu open while home stats finish animating", async () => {
+    vi.useFakeTimers()
+    const harness = await setup({
+      commands: [
+        { name: "/model", description: "Choose a model" },
+        { name: "/settings", description: "Configure Otis" },
+      ],
+    })
+
+    harness.ui.setStats(sampleStats)
+    harness.setChatInput("/")
+    expect(harness.childIds("command-menu")).toEqual(["command-row-0-box", "command-row-1-box"])
+
+    settleStats()
+    await harness.renderOnce()
+
+    expect(harness.childIds("command-menu")).toEqual(["command-row-0-box", "command-row-1-box"])
+    expect(harness.text("command-row-0")).toBe("› /model")
+  })
+
   it("replays the count-up when returning home", async () => {
     vi.useFakeTimers()
     const harness = await setup()

--- a/tests/cli/headless-cli.test.ts
+++ b/tests/cli/headless-cli.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
       fireworksApiKey?: string
       model: string
       modelSupportsImageInput?: boolean
-      fastMode?: boolean
+      fastServingModels?: string[]
       permissions?: PermissionConfig
     }>
   >(async () => ({
@@ -487,7 +487,7 @@ describe("runHeadlessCommand", () => {
     mocks.loadLocalSettings.mockResolvedValue({
       fireworksApiKey: "fw_test",
       model: "accounts/fireworks/models/kimi-k3",
-      fastMode: true,
+      fastServingModels: ["accounts/fireworks/models/kimi-k3"],
     })
     mocks.streamChat.mockImplementationOnce(async function* () {
       yield { type: "text_delta", text: "ok" }
@@ -515,7 +515,7 @@ describe("runHeadlessCommand", () => {
     mocks.loadLocalSettings.mockResolvedValue({
       fireworksApiKey: "fw_test",
       model: "accounts/fireworks/models/kimi-k3",
-      fastMode: true,
+      fastServingModels: ["accounts/fireworks/models/kimi-k3"],
     })
     mocks.streamChat.mockImplementationOnce(async function* () {
       yield { type: "text_delta", text: "ok" }

--- a/tests/cli/interactive-cli-controls.test.ts
+++ b/tests/cli/interactive-cli-controls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getMocks, loadCli, localSettings, submit, testModel } from "./support/interactive-cli-harness.js"
+import { getMocks, loadCli, localSettings, settle, submit, testModel } from "./support/interactive-cli-harness.js"
 
 const mocks = getMocks()
 
@@ -79,6 +79,44 @@ describe("CLI mode toggle", () => {
   })
 })
 
+describe("CLI settings", () => {
+  it("moves debug mode into the settings submenu", async () => {
+    await loadCli()
+
+    const commands = mocks.createChatUI.mock.calls.at(-1)?.[1].commands ?? []
+    expect(commands).toEqual(expect.arrayContaining([expect.objectContaining({ name: "/settings" })]))
+    expect(commands).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: "/debug" })]))
+
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu).toHaveBeenLastCalledWith(
+      [
+        {
+          name: "Hosted inference",
+          description: "Replace API key",
+          submission: "/settings hosted",
+        },
+        {
+          name: "Debug mode",
+          description: "Off",
+          submission: "/settings debug",
+        },
+      ],
+      { onBack: expect.any(Function) },
+    )
+    const onBack = mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[1]?.onBack
+    onBack?.()
+    expect(mocks.ui.showSlashCommandMenu).toHaveBeenCalledOnce()
+
+    await submit("/settings debug")
+    expect(mocks.ui.showTransientHint).toHaveBeenLastCalledWith(" Debug mode on ")
+
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[0]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Debug mode", description: "On" })]),
+    )
+  })
+})
+
 describe("CLI themes", () => {
   it("persists a selected theme without adding a transcript message", async () => {
     await loadCli()
@@ -132,13 +170,13 @@ describe("CLI Fast serving", () => {
       localSettings({
         model: kimi.fastId,
         modelDisplayName: "Kimi K3",
+        fastServingModels: [kimi.id],
       }),
     )
     await loadCli()
 
     await submit("/fast")
-    expect(mocks.saveFastMode).toHaveBeenCalledWith(false)
-    expect(mocks.saveSelectedModel).toHaveBeenCalledWith(kimi)
+    expect(mocks.saveFastServingSelection).toHaveBeenCalledWith(kimi, false)
     expect(mocks.ui.setModelLabel).toHaveBeenLastCalledWith("Kimi K3")
     expect(mocks.ui.showTransientHint).toHaveBeenLastCalledWith(" Fast serving off ")
     expect(mocks.ui.setCommands).toHaveBeenCalledWith(
@@ -146,8 +184,7 @@ describe("CLI Fast serving", () => {
     )
 
     await submit("/fast")
-    expect(mocks.saveFastMode).toHaveBeenLastCalledWith(true)
-    expect(mocks.saveSelectedModel).toHaveBeenLastCalledWith({ ...kimi, id: kimi.fastId })
+    expect(mocks.saveFastServingSelection).toHaveBeenLastCalledWith({ ...kimi, id: kimi.fastId }, true)
     expect(mocks.ui.setModelLabel).toHaveBeenLastCalledWith("Kimi K3 Fast")
     expect(mocks.ui.showTransientHint).toHaveBeenLastCalledWith(" Fast serving on ")
   })
@@ -156,9 +193,56 @@ describe("CLI Fast serving", () => {
     await loadCli()
     await submit("/fast")
 
-    expect(mocks.saveFastMode).not.toHaveBeenCalled()
+    expect(mocks.saveFastServingSelection).not.toHaveBeenCalled()
     expect(mocks.saveSelectedModel).not.toHaveBeenCalled()
     expect(mocks.ui.showTransientHint).toHaveBeenLastCalledWith(" Fast serving is not available for this model ")
     expect(mocks.ui.setCommands).not.toHaveBeenCalled()
   })
+
+  it("remembers Fast serving independently for each model", async () => {
+    const alpha = testModel({
+      id: "accounts/fireworks/models/alpha",
+      displayName: "Alpha",
+      fastId: "accounts/fireworks/routers/alpha-fast",
+    })
+    const beta = testModel({
+      id: "accounts/fireworks/models/beta",
+      displayName: "Beta",
+      fastId: "accounts/fireworks/routers/beta-fast",
+    })
+    mocks.listToolCapableModels.mockResolvedValue([alpha, beta])
+    mocks.loadLocalSettings.mockResolvedValue(
+      localSettings({
+        model: alpha.fastId,
+        modelDisplayName: alpha.displayName,
+        modelFastId: alpha.fastId,
+        fastServingModels: [alpha.id],
+      }),
+    )
+    await loadCli()
+
+    await selectModel(beta.id)
+    expect(mocks.saveSelectedModel).toHaveBeenLastCalledWith(beta)
+
+    await submit("/fast")
+    expect(mocks.saveFastServingSelection).toHaveBeenLastCalledWith({ ...beta, id: beta.fastId }, true)
+
+    await selectModel(alpha.id)
+    expect(mocks.saveSelectedModel).toHaveBeenLastCalledWith({ ...alpha, id: alpha.fastId })
+
+    await submit("/fast")
+    expect(mocks.saveFastServingSelection).toHaveBeenLastCalledWith(alpha, false)
+
+    await selectModel(beta.id)
+    expect(mocks.saveSelectedModel).toHaveBeenLastCalledWith({ ...beta, id: beta.fastId })
+  })
 })
+
+async function selectModel(modelId: string) {
+  await submit("/model")
+  const items = mocks.ui.showModelPicker.mock.calls.at(-1)?.[0] ?? []
+  const model = items.find((item: { id?: string }) => item.id === modelId)
+  if (!model) throw new Error(`Missing model picker item: ${modelId}`)
+  mocks.uiOptions?.onSelectModel?.(model)
+  await settle()
+}

--- a/tests/cli/interactive-cli-lifecycle.test.ts
+++ b/tests/cli/interactive-cli-lifecycle.test.ts
@@ -224,7 +224,7 @@ describe("CLI shutdown", () => {
 
     try {
       await loadCli()
-      await submit(`/delete-model ${cached.id}`)
+      await submit(`/settings delete-model ${cached.id}`)
       await vi.waitFor(() => expect(mocks.deleteLocalGguf).toHaveBeenCalled())
 
       const quitting = Promise.resolve(mocks.uiOptions?.onQuit?.())

--- a/tests/cli/interactive-cli-setup.test.ts
+++ b/tests/cli/interactive-cli-setup.test.ts
@@ -38,8 +38,16 @@ describe("interactive CLI setup", () => {
     expect(mocks.uiOptions?.modelLabel).toBe("")
     expect(mocks.calculateLocalStats).not.toHaveBeenCalled()
     mocks.uiOptions?.onSetup?.()
+    expect(mocks.ui.showSetupInferenceChoice).toHaveBeenCalledOnce()
+    expect(mocks.ui.showSetupInput).not.toHaveBeenCalled()
+    expect(mocks.openFireworksKeyPage).not.toHaveBeenCalled()
+
+    mocks.uiOptions?.onSetupInferenceChoice?.("hosted")
     expect(mocks.ui.showSetupInput).toHaveBeenCalledOnce()
     expect(mocks.openFireworksKeyPage).toHaveBeenCalledOnce()
+
+    mocks.uiOptions?.onSetupSubmit?.(" ")
+    expect(mocks.ui.showSetupError).toHaveBeenLastCalledWith("Fireworks API key is required.", "choice")
 
     mocks.uiOptions?.onSetupSubmit?.("fw_new_key")
     await settle()
@@ -51,6 +59,137 @@ describe("interactive CLI setup", () => {
     expect(mocks.ui.setModelLabel).toHaveBeenLastCalledWith("Muse Glimmer 30B")
     expect(mocks.ui.setConfigured).toHaveBeenCalledOnce()
     expect(mocks.ParallelClient).toHaveBeenCalledOnce()
+  })
+
+  it("opens the hardware-filtered local catalog without asking for a Fireworks key", async () => {
+    mocks.loadLocalSettings.mockResolvedValue(
+      localSettings({
+        fireworksApiKey: undefined,
+        model: undefined,
+        modelDisplayName: undefined,
+        modelContextLength: undefined,
+      }),
+    )
+    await loadCli()
+
+    mocks.uiOptions?.onSetup?.()
+    mocks.uiOptions?.onSetupInferenceChoice?.("local")
+    await vi.waitFor(() => expect(mocks.ui.showModelPicker).toHaveBeenCalledOnce())
+
+    expect(mocks.ui.showSetupStatus).toHaveBeenCalledOnce()
+    expect(mocks.listToolCapableModels).not.toHaveBeenCalled()
+    expect(mocks.openFireworksKeyPage).not.toHaveBeenCalled()
+    expect(mocks.ui.showSetupInput).not.toHaveBeenCalled()
+    const picker = (mocks.ui.showModelPicker.mock.calls[0]?.[0] ?? []) as ModelPickerItem[]
+    expect(picker[0]).toMatchObject({ kind: "header", displayName: "Local" })
+    expect(picker).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "openai/gpt-oss-20b", provider: "local" })]),
+    )
+    expect(picker).not.toEqual(expect.arrayContaining([expect.objectContaining({ provider: "fireworks" })]))
+  })
+
+  it("adds a validated hosted key from settings without replacing the active local model", async () => {
+    const local = findLocalModel("openai/gpt-oss-20b")
+    if (!local) throw new Error("missing local model")
+    const hosted = testModel({ displayName: "Hosted Model" })
+    mocks.listToolCapableModels.mockResolvedValue([hosted])
+    mocks.loadLocalSettings.mockResolvedValue(
+      localSettings({
+        fireworksApiKey: undefined,
+        model: local.id,
+        modelDisplayName: local.displayName,
+        modelContextLength: 32_768,
+        modelProvider: "local",
+      }),
+    )
+    await loadCli()
+    mocks.saveSelectedModel.mockClear()
+
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[0]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Hosted inference", description: "Add API key" })]),
+    )
+
+    await submit("/settings hosted")
+    expect(mocks.ui.showSetupInput).toHaveBeenLastCalledWith("", "configured")
+    expect(mocks.openFireworksKeyPage).toHaveBeenCalledOnce()
+
+    mocks.uiOptions?.onSetupSubmit?.("fw_added_key")
+    await vi.waitFor(() => expect(mocks.saveFireworksApiKey).toHaveBeenCalledWith("fw_added_key"))
+
+    expect(mocks.listToolCapableModels).toHaveBeenCalledWith("fw_added_key", {
+      signal: expect.any(AbortSignal),
+    })
+    expect(mocks.saveSelectedModel).not.toHaveBeenCalled()
+    expect(mocks.saveFireworksSetup).not.toHaveBeenCalled()
+    expect(mocks.ui.showTransientHint).toHaveBeenLastCalledWith(" Hosted inference configured ")
+
+    mocks.ui.showModelPicker.mockClear()
+    await submit("/model")
+    const picker = (mocks.ui.showModelPicker.mock.calls[0]?.[0] ?? []) as ModelPickerItem[]
+    expect(picker).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "header", displayName: "Hosted" }),
+        expect.objectContaining({ id: hosted.id, provider: "fireworks" }),
+      ]),
+    )
+  })
+
+  it("keeps hosted key settings open when validation fails", async () => {
+    mocks.listToolCapableModels.mockRejectedValue(new Error("invalid API key"))
+    await loadCli()
+
+    await submit("/settings hosted")
+    mocks.uiOptions?.onSetupSubmit?.("fw_invalid")
+    await vi.waitFor(() => expect(mocks.ui.showSetupError).toHaveBeenCalledWith("invalid API key", "configured"))
+
+    expect(mocks.saveFireworksApiKey).not.toHaveBeenCalled()
+  })
+
+  it("discards a rejected hosted key draft when onboarding switches to local", async () => {
+    const hosted = testModel({ displayName: "Hosted Model" })
+    mocks.listToolCapableModels.mockImplementation(async (apiKey) => {
+      if (apiKey === "fw_rejected") throw new Error("invalid API key")
+      return [hosted]
+    })
+    mocks.loadLocalSettings.mockResolvedValue(
+      localSettings({
+        fireworksApiKey: undefined,
+        model: undefined,
+        modelDisplayName: undefined,
+        modelContextLength: undefined,
+      }),
+    )
+    await loadCli()
+
+    mocks.uiOptions?.onSetup?.()
+    mocks.uiOptions?.onSetupInferenceChoice?.("hosted")
+    mocks.uiOptions?.onSetupSubmit?.("fw_rejected")
+    await vi.waitFor(() => expect(mocks.ui.showSetupError).toHaveBeenCalledWith("invalid API key", "choice"))
+
+    mocks.uiOptions?.onSetupInferenceChoice?.("local")
+    await vi.waitFor(() => expect(mocks.ui.showModelPicker).toHaveBeenCalled())
+    const localPicker = (mocks.ui.showModelPicker.mock.calls.at(-1)?.[0] ?? []) as ModelPickerItem[]
+    const local = localPicker.find((item) => "provider" in item && item.provider === "local" && item.available)
+    if (!local) throw new Error("missing runnable local model")
+    mocks.uiOptions?.onSelectModel?.(local)
+    await vi.waitFor(() => expect(mocks.ui.setConfigured).toHaveBeenCalled())
+
+    await submit("/settings hosted")
+    mocks.uiOptions?.onSetupSubmit?.("fw_valid")
+    await vi.waitFor(() => expect(mocks.saveFireworksApiKey).toHaveBeenCalledWith("fw_valid"))
+
+    mocks.ui.showModelPicker.mockClear()
+    mocks.saveSelectedModel.mockClear()
+    await submit("/model")
+    const modelPicker = (mocks.ui.showModelPicker.mock.calls.at(-1)?.[0] ?? []) as ModelPickerItem[]
+    const hostedChoice = modelPicker.find((item) => "provider" in item && item.provider === "fireworks")
+    if (!hostedChoice) throw new Error("missing hosted model")
+    mocks.uiOptions?.onSelectModel?.(hostedChoice)
+    await settle()
+
+    expect(mocks.saveFireworksSetup).not.toHaveBeenCalled()
+    expect(mocks.saveSelectedModel).toHaveBeenCalledWith(hosted)
   })
 
   it("falls back to Inkling and does not copy an environment key into the config file", async () => {
@@ -119,12 +258,14 @@ describe("interactive CLI setup", () => {
     await loadCli()
 
     mocks.uiOptions?.onSetup?.()
+    mocks.uiOptions?.onSetupInferenceChoice?.("hosted")
     mocks.uiOptions?.onSetupSubmit?.("fw_new_key")
     await settle()
 
     expect(mocks.saveFireworksSetup).not.toHaveBeenCalled()
     expect(mocks.ui.showSetupError).toHaveBeenCalledWith(
-      "Fireworks returned no public serverless models with tool support.",
+      "The hosted provider returned no public models with tool support.",
+      "choice",
     )
     expect(mocks.ui.setConfigured).not.toHaveBeenCalled()
   })
@@ -142,10 +283,11 @@ describe("interactive CLI setup", () => {
     await loadCli()
 
     mocks.uiOptions?.onSetup?.()
+    mocks.uiOptions?.onSetupInferenceChoice?.("hosted")
     mocks.uiOptions?.onSetupSubmit?.("fw_new_key")
     await settle()
 
-    expect(mocks.ui.showSetupError).toHaveBeenCalledWith("Could not save Fireworks setup.")
+    expect(mocks.ui.showSetupError).toHaveBeenCalledWith("Could not save Fireworks setup.", "choice")
     expect(mocks.ui.setConfigured).not.toHaveBeenCalled()
   })
 
@@ -177,6 +319,7 @@ describe("interactive CLI setup", () => {
 
     expect(mocks.uiOptions?.configured).toBe(true)
     expect(mocks.calculateLocalStats).toHaveBeenCalled()
+    expect(mocks.ui.setConfigured).not.toHaveBeenCalled()
   })
 
   it("advertises /fast when the saved model has a Fast serving path", async () => {
@@ -185,28 +328,53 @@ describe("interactive CLI setup", () => {
         model: "accounts/fireworks/models/kimi-k3",
         modelDisplayName: "Kimi K3",
         modelFastId: "accounts/fireworks/routers/kimi-k3-fast",
-        fastMode: false,
       }),
     )
     await loadCli()
     expect(commandNames()).toContain("/fast")
   })
 
-  it("advertises local model deletion only when a model is downloaded", async () => {
+  it("offers local model deletion from settings only when a model is downloaded", async () => {
     const cached = findLocalModel("openai/gpt-oss-20b")
     if (!cached) throw new Error("missing local model")
     mocks.listDownloadedLocalModels.mockResolvedValue([cached])
 
     await loadCli()
 
-    expect(commandNames()).toContain("/delete-model")
-    await submit("/delete-model")
-    expect(mocks.ui.showCommandSubmenu).toHaveBeenCalledWith([
-      expect.objectContaining({
-        name: cached.displayName,
-        submission: `/delete-model ${cached.id}`,
-      }),
-    ])
+    expect(commandNames()).not.toContain("/delete-model")
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        {
+          name: "Delete local model",
+          description: "Choose a downloaded model",
+          submission: "/settings delete-model",
+        },
+      ]),
+      { onBack: expect.any(Function) },
+    )
+
+    await submit("/settings delete-model")
+    expect(mocks.ui.showCommandSubmenu).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          name: cached.displayName,
+          submission: `/settings delete-model ${cached.id}`,
+        }),
+      ],
+      { onBack: expect.any(Function) },
+    )
+
+    const onBack = mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[1]?.onBack
+    expect(onBack).toBeTypeOf("function")
+    onBack?.()
+    expect(mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Hosted inference" }),
+        expect.objectContaining({ name: "Delete local model" }),
+        expect.objectContaining({ name: "Debug mode" }),
+      ]),
+    )
   })
 
   it("opens the verified model catalog from the model command", async () => {
@@ -308,7 +476,7 @@ describe("interactive CLI setup", () => {
       fastId: "accounts/fireworks/routers/kimi-k3-fast",
     })
     mocks.listToolCapableModels.mockResolvedValue([kimi])
-    mocks.loadLocalSettings.mockResolvedValue(localSettings({ fastMode: true }))
+    mocks.loadLocalSettings.mockResolvedValue(localSettings({ fastServingModels: [kimi.id] }))
     await loadCli()
     await submit("/model")
 
@@ -332,7 +500,7 @@ describe("interactive CLI setup", () => {
       fastId: "accounts/fireworks/routers/kimi-k3-fast",
     })
     mocks.listToolCapableModels.mockResolvedValue([kimi])
-    mocks.loadLocalSettings.mockResolvedValue(localSettings({ fastMode: false }))
+    mocks.loadLocalSettings.mockResolvedValue(localSettings({ fastServingModels: [] }))
     await loadCli()
     await submit("/model")
 
@@ -363,14 +531,22 @@ describe("interactive CLI setup", () => {
     expect(mocks.ensureLocalServing).toHaveBeenCalled()
     expect(mocks.ui.showTransientHint).not.toHaveBeenCalledWith(expect.stringMatching(/Starting /))
     expect(mocks.ui.showHomeLayout).not.toHaveBeenCalled()
-    expect(mocks.ui.setModelPickerStatus).toHaveBeenCalledWith("openai/gpt-oss-20b", "47%")
-    expect(mocks.ui.setModelPickerStatus).toHaveBeenCalledWith("openai/gpt-oss-20b", "Loading")
+    expect(mocks.ui.setModelPickerStatus).toHaveBeenCalledWith("openai/gpt-oss-20b", {
+      label: "Downloading 47%",
+      kind: "progress",
+    })
+    expect(mocks.ui.setModelPickerStatus).toHaveBeenCalledWith("openai/gpt-oss-20b", {
+      label: "Loading",
+      kind: "progress",
+    })
     expect(mocks.ui.setModelLabel).toHaveBeenLastCalledWith("gpt-oss 20B")
     expect(mocks.ui.setModelLabel).not.toHaveBeenCalledWith(expect.stringMatching(/%|loading/i))
     expect(mocks.ui.hideModelPicker).toHaveBeenCalled()
     expect(mocks.ui.setConfigured).toHaveBeenCalled()
-    expect(mocks.ui.setCommands).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.objectContaining({ name: "/delete-model" })]),
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu).toHaveBeenLastCalledWith(
+      expect.arrayContaining([expect.objectContaining({ name: "Delete local model" })]),
+      { onBack: expect.any(Function) },
     )
 
     mocks.ui.showModelPicker.mockClear()
@@ -388,7 +564,7 @@ describe("interactive CLI setup", () => {
           (item): item is LocalPickerChoice =>
             item.kind === "model" && item.provider === "local" && item.id !== "openai/gpt-oss-20b",
         )
-        .every((item) => item.availabilityLabel.startsWith("Up to ")),
+        .every((item) => item.availabilityLabel.startsWith("Est. ")),
     ).toBe(true)
   })
 
@@ -400,12 +576,15 @@ describe("interactive CLI setup", () => {
       mocks.listDownloadedLocalModels.mockResolvedValue([])
     })
     await loadCli()
-    await submit(`/delete-model ${cached.id}`)
+    await submit(`/settings delete-model ${cached.id}`)
     await vi.waitFor(() => expect(mocks.deleteLocalGguf).toHaveBeenCalledWith(cached))
 
     expect(mocks.stopLocalRuntime).toHaveBeenCalledOnce()
     expect(mocks.clearSelectedModel).not.toHaveBeenCalled()
-    expect(latestCommandNames()).not.toContain("/delete-model")
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[0]).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Delete local model" })]),
+    )
   })
 
   it("deletes an inactive model without interrupting a different active local model", async () => {
@@ -427,18 +606,21 @@ describe("interactive CLI setup", () => {
     await loadCli()
     mocks.stopLocalRuntime.mockClear()
 
-    await submit(`/delete-model ${inactive.id}`)
+    await submit(`/settings delete-model ${inactive.id}`)
     await vi.waitFor(() => expect(mocks.deleteLocalGguf).toHaveBeenCalledWith(inactive))
 
     expect(mocks.stopLocalRuntime).not.toHaveBeenCalled()
     expect(mocks.clearSelectedModel).not.toHaveBeenCalled()
-    expect(mocks.ui.showCommandSubmenu).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        name: active.displayName,
-        description: expect.stringContaining("Active ·"),
-        submission: `/delete-model ${active.id}`,
-      }),
-    ])
+    expect(mocks.ui.showCommandSubmenu).toHaveBeenLastCalledWith(
+      [
+        expect.objectContaining({
+          name: active.displayName,
+          description: expect.stringContaining("Active ·"),
+          submission: `/settings delete-model ${active.id}`,
+        }),
+      ],
+      { onBack: expect.any(Function) },
+    )
   })
 
   it("stops llama.cpp and clears selection before deleting the active local model", async () => {
@@ -459,16 +641,18 @@ describe("interactive CLI setup", () => {
     await loadCli()
     mocks.stopLocalRuntime.mockClear()
 
-    await submit(`/delete-model ${cached.id}`)
+    await submit(`/settings delete-model ${cached.id}`)
     await vi.waitFor(() => expect(mocks.deleteLocalGguf).toHaveBeenCalledWith(cached))
 
     expect(mocks.clearSelectedModel).toHaveBeenCalledBefore(mocks.stopLocalRuntime)
     expect(mocks.stopLocalRuntime).toHaveBeenCalledBefore(mocks.deleteLocalGguf)
     expect(mocks.ui.showHomeLayout).not.toHaveBeenCalled()
-    expect(mocks.ui.showSetupButton).not.toHaveBeenCalled()
     expect(mocks.ui.setModelLabel).toHaveBeenCalledWith("No model")
     await vi.waitFor(() => expect(mocks.ui.showModelPicker).toHaveBeenCalled())
-    expect(latestCommandNames()).not.toContain("/delete-model")
+    await submit("/settings")
+    expect(mocks.ui.showCommandSubmenu.mock.calls.at(-1)?.[0]).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Delete local model" })]),
+    )
   })
 
   it("restores an active local selection when its model file cannot be deleted", async () => {
@@ -487,7 +671,7 @@ describe("interactive CLI setup", () => {
     await loadCli()
     mocks.saveSelectedModel.mockClear()
 
-    await submit(`/delete-model ${cached.id}`)
+    await submit(`/settings delete-model ${cached.id}`)
     await vi.waitFor(() => expect(mocks.ui.showTransientHint).toHaveBeenCalledWith(expect.stringContaining("locked")))
 
     expect(mocks.clearSelectedModel).toHaveBeenCalled()
@@ -515,7 +699,11 @@ describe("interactive CLI setup", () => {
     expect(mocks.saveSelectedModel).not.toHaveBeenCalled()
     expect(mocks.ui.hideModelPicker).not.toHaveBeenCalled()
     expect(mocks.ui.setModelLabel).not.toHaveBeenCalledWith("gpt-oss 20B")
-    expect(mocks.ui.showSetupError).toHaveBeenCalledWith("model failed to load")
+    expect(mocks.ui.setModelPickerStatus).toHaveBeenLastCalledWith(local.id, {
+      label: "Failed: model failed to load",
+      kind: "error",
+    })
+    expect(mocks.ui.showSetupError).not.toHaveBeenCalled()
   })
 
   it("rolls back a prepared local runtime when saving the selection fails", async () => {
@@ -536,7 +724,11 @@ describe("interactive CLI setup", () => {
     expect(mocks.stopLocalRuntime).toHaveBeenCalledOnce()
     expect(mocks.ui.hideModelPicker).not.toHaveBeenCalled()
     expect(mocks.ui.setModelLabel).not.toHaveBeenCalledWith("gpt-oss 20B")
-    expect(mocks.ui.showSetupError).toHaveBeenCalledWith("config is read-only")
+    expect(mocks.ui.setModelPickerStatus).toHaveBeenLastCalledWith(local.id, {
+      label: "Failed: config is read-only",
+      kind: "error",
+    })
+    expect(mocks.ui.showSetupError).not.toHaveBeenCalled()
   })
 
   it("does not let a stale local load complete a newer selection", async () => {
@@ -644,9 +836,4 @@ describe("interactive CLI setup", () => {
 function commandNames() {
   const commands = getMocks().createChatUI.mock.calls.at(-1)?.[1]?.commands as Array<{ name: string }> | undefined
   return commands?.map((command) => command.name) ?? []
-}
-
-function latestCommandNames() {
-  const commands = getMocks().ui.setCommands.mock.calls.at(-1)?.[0] as Array<{ name: string }> | undefined
-  return commands?.map((command) => command.name) ?? commandNames()
 }

--- a/tests/cli/slash-commands.test.ts
+++ b/tests/cli/slash-commands.test.ts
@@ -11,11 +11,23 @@ describe("slash commands", () => {
   it("parses known commands and leaves unknown input for the agent", () => {
     expect(parseSlashCommand("/exit")).toEqual({ type: "exit" })
     expect(parseSlashCommand("/fast")).toEqual({ type: "fast" })
-    expect(parseSlashCommand("/delete-model")).toEqual({ type: "delete-model" })
+    expect(parseSlashCommand("/delete-model")).toEqual({ type: "settings", setting: "delete-model" })
     expect(parseSlashCommand("/delete-model openai/gpt-oss-20b")).toEqual({
-      type: "delete-model",
+      type: "settings",
+      setting: "delete-model",
       modelId: "openai/gpt-oss-20b",
     })
+    expect(parseSlashCommand("/settings")).toEqual({ type: "settings" })
+    expect(parseSlashCommand("/settings hosted")).toEqual({ type: "settings", setting: "hosted" })
+    expect(parseSlashCommand("/settings debug")).toEqual({ type: "settings", setting: "debug" })
+    expect(parseSlashCommand("/settings delete-model")).toEqual({ type: "settings", setting: "delete-model" })
+    expect(parseSlashCommand("/settings delete-model openai/gpt-oss-20b")).toEqual({
+      type: "settings",
+      setting: "delete-model",
+      modelId: "openai/gpt-oss-20b",
+    })
+    expect(parseSlashCommand("/settings unknown")).toBeUndefined()
+    expect(parseSlashCommand("/debug")).toEqual({ type: "settings", setting: "debug" })
     expect(parseSlashCommand("/theme")).toEqual({ type: "theme-menu" })
     expect(parseSlashCommand("/theme nord")).toEqual({ type: "theme", name: "nord" })
     expect(parseSlashCommand("/compact")).toEqual({ type: "compact" })
@@ -38,20 +50,19 @@ describe("slash commands", () => {
 
   it("advertises every built-in command including theme names", () => {
     const names = SLASH_COMMANDS.map((command) => command.name)
-    expect(names.slice(0, 10)).toEqual([
+    expect(names.slice(0, 9)).toEqual([
       "/home",
       "/new",
       "/history",
       "/model",
-      "/delete-model",
+      "/settings",
       "/fast",
       "/compact",
-      "/debug",
       "/thinking",
       "/theme",
     ])
     expect(names.at(-1)).toBe("/exit")
-    expect(names.slice(10, -1)).toEqual(THEME_NAMES.map((theme) => `/theme ${theme}`))
+    expect(names.slice(9, -1)).toEqual(THEME_NAMES.map((theme) => `/theme ${theme}`))
   })
 
   it("omits /fast unless the current model has a Fast serving path", () => {
@@ -60,9 +71,9 @@ describe("slash commands", () => {
     expect(parseSlashCommand("/fast")).toEqual({ type: "fast" })
   })
 
-  it("omits /delete-model unless a local model is downloaded", () => {
-    expect(slashCommands({ downloadedModels: true }).some((command) => command.name === "/delete-model")).toBe(true)
-    expect(slashCommands({ downloadedModels: false }).some((command) => command.name === "/delete-model")).toBe(false)
+  it("keeps the former model deletion command as an unadvertised alias", () => {
+    expect(SLASH_COMMANDS.some((command) => command.name === "/delete-model")).toBe(false)
+    expect(parseSlashCommand("/delete-model")).toEqual({ type: "settings", setting: "delete-model" })
   })
 
   it("parses every advertised command", () => {

--- a/tests/cli/support/interactive-cli-harness.ts
+++ b/tests/cli/support/interactive-cli-harness.ts
@@ -60,9 +60,10 @@ const mocks = vi.hoisted(() => {
     showPermissionPrompt: vi.fn(() => Promise.resolve(true)),
     showSessionPicker: vi.fn(),
     showSetupError: vi.fn(),
-    showSetupButton: vi.fn(),
+    showSetupInferenceChoice: vi.fn(),
     showSetupInput: vi.fn(),
     showSetupStatus: vi.fn(),
+    showSlashCommandMenu: vi.fn(),
     showStats: vi.fn(),
     showTransientHint: vi.fn(),
     showUpdateHint: vi.fn(),
@@ -108,11 +109,12 @@ const mocks = vi.hoisted(() => {
     loadSkillCatalog: vi.fn<() => Promise<SkillCatalog>>(async () => ({ skills: [], byName: new Map() })),
     openSession: vi.fn(),
     openFireworksKeyPage: vi.fn(async () => true),
+    saveFireworksApiKey: vi.fn(async () => undefined),
     saveFireworksSetup: vi.fn(async () => undefined),
     saveSelectedModel: vi.fn(async () => undefined),
     saveSelectedTheme: vi.fn(async () => undefined),
     saveThinkingVisible: vi.fn(async () => undefined),
-    saveFastMode: vi.fn(async () => undefined),
+    saveFastServingSelection: vi.fn(async () => undefined),
     detectHardware: vi.fn(async () => ({
       platform: "darwin" as const,
       arch: "arm64",
@@ -163,6 +165,7 @@ const mocks = vi.hoisted(() => {
           onSelectModel?(model: import("../../../src/inference/picker-catalog.js").ModelPickerItem): void
           onSelectSession?(sessionId: string): void
           onSetup?(): void
+          onSetupInferenceChoice?(choice: "local" | "hosted"): void
           onSetupSubmit?(apiKey: string): void
           onSubmit(value: string): void | Promise<void>
           onToggleMode?(): void
@@ -202,11 +205,12 @@ vi.mock("../../../src/local/settings.js", () => ({
     ["default", "nord", "bright", "matrix", "midnight", "graphite", "beige", "vice", "eagan"].includes(String(value)),
   clearSelectedModel: mocks.clearSelectedModel,
   loadLocalSettings: mocks.loadLocalSettings,
+  saveFireworksApiKey: mocks.saveFireworksApiKey,
   saveFireworksSetup: mocks.saveFireworksSetup,
   saveSelectedModel: mocks.saveSelectedModel,
   saveSelectedTheme: mocks.saveSelectedTheme,
   saveThinkingVisible: mocks.saveThinkingVisible,
-  saveFastMode: mocks.saveFastMode,
+  saveFastServingSelection: mocks.saveFastServingSelection,
 }))
 vi.mock("../../../src/local/stats.js", () => ({ calculateLocalStats: mocks.calculateLocalStats }))
 vi.mock("../../../src/storage/index.js", () => ({

--- a/tests/inference/gguf-cache.test.ts
+++ b/tests/inference/gguf-cache.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, readFile, rm, stat, truncate, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -10,7 +11,7 @@ import {
   listDownloadedLocalModels,
   localGgufPath,
 } from "../../src/inference/gguf-cache.js"
-import { findLocalModel } from "../../src/inference/local-catalog.js"
+import { findLocalModel, type LocalModelSpec } from "../../src/inference/local-catalog.js"
 
 const tempDirectories: string[] = []
 
@@ -19,18 +20,14 @@ afterEach(async () => {
 })
 
 describe("local GGUF cache", () => {
-  it("downloads the Hugging Face file with percent progress", async () => {
-    const model = catalogModel()
+  it("downloads and verifies the pinned Hugging Face file with percent progress", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
     const directory = await tempDir()
     const percents: number[] = []
-    const body = new Uint8Array([1, 2, 3, 4])
     const dest = await ensureLocalGguf(model, {
       dataDirectory: directory,
-      fetch: (async () =>
-        new Response(Buffer.from(body), {
-          status: 200,
-          headers: { "content-length": String(body.byteLength) },
-        })) as typeof fetch,
+      fetch: response(body),
       onProgress: (percent) => percents.push(percent),
     })
 
@@ -38,93 +35,181 @@ describe("local GGUF cache", () => {
     expect(await readFile(dest)).toEqual(Buffer.from(body))
     expect(percents.at(-1)).toBe(100)
     expect(await isLocalGgufDownloaded(model, directory)).toBe(true)
+    await expect(readFile(`${dest}.otis.json`, "utf8")).resolves.toContain(model.ggufSha256)
   })
 
-  it("skips the network when the GGUF is already on disk", async () => {
+  it("verifies a legacy cached GGUF once and then skips the network", async () => {
+    const body = new Uint8Array([4, 3, 2, 1])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const dest = localGgufPath(model, directory)
+    await mkdir(join(directory, "models"), { recursive: true })
+    await writeFile(dest, body)
+    const fetchImpl = vi.fn(async () => new Response("no", { status: 500 })) as unknown as typeof fetch
+
+    await ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
+    await ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    await expect(readFile(`${dest}.otis.json`, "utf8")).resolves.toContain(model.ggufRevision)
+  })
+
+  it("replaces a same-size cached file whose checksum is wrong", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const dest = localGgufPath(model, directory)
+    await mkdir(join(directory, "models"), { recursive: true })
+    await writeFile(dest, new Uint8Array([9, 9, 9, 9]))
+
+    await ensureLocalGguf(model, { dataDirectory: directory, fetch: response(body) })
+
+    expect(await readFile(dest)).toEqual(Buffer.from(body))
+  })
+
+  it("resumes a partial download with an exact byte range", async () => {
+    const body = new Uint8Array([1, 2, 3, 4, 5, 6])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const dest = localGgufPath(model, directory)
+    await mkdir(join(directory, "models"), { recursive: true })
+    await writeFile(`${dest}.partial`, body.slice(0, 3))
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("range")).toBe("bytes=3-")
+      return new Response(body.slice(3), {
+        status: 206,
+        headers: { "content-length": "3", "content-range": "bytes 3-5/6" },
+      })
+    }) as unknown as typeof fetch
+
+    await ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
+
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(await readFile(dest)).toEqual(Buffer.from(body))
+    await expect(stat(`${dest}.partial`)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("restarts cleanly when a server ignores the requested range", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const dest = localGgufPath(model, directory)
+    await mkdir(join(directory, "models"), { recursive: true })
+    await writeFile(`${dest}.partial`, body.slice(0, 2))
+
+    await ensureLocalGguf(model, { dataDirectory: directory, fetch: response(body) })
+
+    expect(await readFile(dest)).toEqual(Buffer.from(body))
+  })
+
+  it("rejects a resumed response that does not cover the exact remaining range", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const partial = `${localGgufPath(model, directory)}.partial`
+    await mkdir(join(directory, "models"), { recursive: true })
+    await writeFile(partial, body.slice(0, 2))
+
+    await expect(
+      ensureLocalGguf(model, {
+        dataDirectory: directory,
+        fetch: (async () =>
+          new Response(body.slice(2), {
+            status: 206,
+            headers: { "content-length": "2", "content-range": "bytes 2-2/4" },
+          })) as typeof fetch,
+      }),
+    ).rejects.toThrow("invalid byte range")
+    await expect(readFile(partial)).resolves.toEqual(Buffer.from(body.slice(0, 2)))
+  })
+
+  it("retains a partial file when the download is aborted", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const abort = new AbortController()
+    await expect(
+      ensureLocalGguf(model, {
+        dataDirectory: directory,
+        signal: abort.signal,
+        fetch: response(body.slice(0, 2), model.weightBytes),
+        onProgress: (percent) => {
+          if (percent === 50) abort.abort()
+        },
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+
+    await expect(readFile(`${localGgufPath(model, directory)}.partial`)).resolves.toEqual(Buffer.from([1, 2]))
+    expect(await isLocalGgufDownloaded(model, directory)).toBe(false)
+  })
+
+  it("serializes concurrent callers and publishes one verified download", async () => {
+    const body = new Uint8Array([1, 2])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    let stream: ReadableStreamDefaultController<Uint8Array> | undefined
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              stream = controller
+            },
+          }),
+          { status: 200, headers: { "content-length": "2" } },
+        ),
+    ) as unknown as typeof fetch
+
+    const first = ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
+    const second = ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
+    await vi.waitFor(() => expect(stream).toBeDefined())
+    stream?.enqueue(body)
+    stream?.close()
+    await Promise.all([first, second])
+
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(await readFile(localGgufPath(model, directory))).toEqual(Buffer.from(body))
+  })
+
+  it("rejects and removes a completed partial whose checksum is wrong", async () => {
+    const body = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(body)
+    const directory = await tempDir()
+    const dest = localGgufPath(model, directory)
+
+    await expect(
+      ensureLocalGguf(model, {
+        dataDirectory: directory,
+        fetch: response(new Uint8Array([4, 3, 2, 1])),
+      }),
+    ).rejects.toThrow("SHA-256 verification failed")
+    await expect(stat(`${dest}.partial`)).rejects.toMatchObject({ code: "ENOENT" })
+    expect(await isLocalGgufDownloaded(model, directory)).toBe(false)
+  })
+
+  it("lists completed catalog files and deletes their data and partial state", async () => {
     const model = catalogModel()
     const directory = await tempDir()
     const dest = localGgufPath(model, directory)
     await mkdir(join(directory, "models"), { recursive: true })
-    await writeFile(dest, "cached")
-    let fetched = false
-    await ensureLocalGguf(model, {
-      dataDirectory: directory,
-      fetch: (async () => {
-        fetched = true
-        return new Response("no", { status: 500 })
-      }) as typeof fetch,
-    })
-    expect(fetched).toBe(false)
-    expect(await readFile(dest, "utf8")).toBe("cached")
-  })
-
-  it("lists and deletes only completed local model files", async () => {
-    const model = catalogModel()
-    const directory = await tempDir()
-    await mkdir(join(directory, "models"), { recursive: true })
-    await writeFile(localGgufPath(model, directory), "cached")
-    await writeFile(`${localGgufPath(model, directory)}.partial`, "unfinished")
+    await writeFile(dest, "")
+    await truncate(dest, model.weightBytes)
+    await writeFile(`${dest}.partial`, "unfinished")
+    await writeFile(`${dest}.otis.json`, "manifest")
 
     await expect(listDownloadedLocalModels(directory)).resolves.toEqual([model])
     await deleteLocalGguf(model, directory)
     await deleteLocalGguf(model, directory)
     await expect(listDownloadedLocalModels(directory)).resolves.toEqual([])
-    await expect(readFile(`${localGgufPath(model, directory)}.partial`, "utf8")).resolves.toBe("unfinished")
+    await expect(stat(`${dest}.partial`)).rejects.toMatchObject({ code: "ENOENT" })
+    await expect(stat(`${dest}.otis.json`)).rejects.toMatchObject({ code: "ENOENT" })
   })
 
-  it("deletes a partial file when the download is aborted", async () => {
+  it("builds an immutable Hugging Face resolve URL", () => {
     const model = catalogModel()
-    const directory = await tempDir()
-    const abort = new AbortController()
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array([1, 2]))
-        abort.abort()
-      },
-    })
-    await expect(
-      ensureLocalGguf(model, {
-        dataDirectory: directory,
-        signal: abort.signal,
-        fetch: (async () => new Response(body, { status: 200, headers: { "content-length": "4" } })) as typeof fetch,
-      }),
-    ).rejects.toMatchObject({ name: "AbortError" })
-
-    await expect(stat(`${localGgufPath(model, directory)}.partial`)).rejects.toMatchObject({ code: "ENOENT" })
-    expect(await isLocalGgufDownloaded(model, directory)).toBe(false)
-  })
-
-  it("publishes concurrent downloads from isolated partial files", async () => {
-    const model = catalogModel()
-    const directory = await tempDir()
-    const bodies: ReadableStreamDefaultController<Uint8Array>[] = []
-    const fetchImpl = (async () =>
-      new Response(
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            bodies.push(controller)
-          },
-        }),
-        { status: 200, headers: { "content-length": "2" } },
-      )) as typeof fetch
-
-    const first = ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
-    const second = ensureLocalGguf(model, { dataDirectory: directory, fetch: fetchImpl })
-    await vi.waitFor(() => expect(bodies).toHaveLength(2))
-
-    bodies[0]?.enqueue(new Uint8Array([1, 2]))
-    bodies[0]?.close()
-    bodies[1]?.enqueue(new Uint8Array([1, 2]))
-    bodies[1]?.close()
-    await Promise.all([first, second])
-
-    expect(await readFile(localGgufPath(model, directory))).toEqual(Buffer.from([1, 2]))
-    expect((await readdir(join(directory, "models"))).filter((name) => name.endsWith(".partial"))).toEqual([])
-  })
-
-  it("builds the official Hugging Face resolve URL", () => {
-    const model = catalogModel()
-    expect(huggingFaceGgufUrl(model)).toBe(`https://huggingface.co/${model.ggufRepo}/resolve/main/${model.ggufFile}`)
+    expect(huggingFaceGgufUrl(model)).toBe(
+      `https://huggingface.co/${model.ggufRepo}/resolve/${model.ggufRevision}/${model.ggufFile}`,
+    )
   })
 })
 
@@ -138,4 +223,20 @@ function catalogModel() {
   const model = findLocalModel("openai/gpt-oss-20b")
   if (!model) throw new Error("missing catalog entry")
   return model
+}
+
+function tinyModel(body: Uint8Array): LocalModelSpec {
+  return {
+    ...catalogModel(),
+    weightBytes: body.byteLength,
+    ggufSha256: createHash("sha256").update(body).digest("hex"),
+  }
+}
+
+function response(body: Uint8Array, contentLength = body.byteLength): typeof fetch {
+  return (async () =>
+    new Response(Buffer.from(body), {
+      status: 200,
+      headers: { "content-length": String(contentLength) },
+    })) as typeof fetch
 }

--- a/tests/inference/hardware.test.ts
+++ b/tests/inference/hardware.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  availableInferenceMemory,
-  currentlyAvailableInferenceMemory,
-  detectHardware,
-  inferenceMemoryBudget,
-} from "../../src/inference/hardware.js"
+import { availableModelMemory, detectHardware, inferenceMemoryBudget } from "../../src/inference/hardware.js"
 
 describe("hardware detection", () => {
   it("treats Apple Silicon as Metal with unified memory", async () => {
@@ -19,35 +14,31 @@ describe("hardware detection", () => {
     })
     const budget = inferenceMemoryBudget(hardware)
     expect(budget.deviceHeadroomBytes).toBe(9_831 * 1024 ** 2)
-    expect(availableInferenceMemory(hardware)).toBe(hardware.totalMemoryBytes - budget.deviceHeadroomBytes)
+    expect(availableModelMemory(hardware)).toBe(hardware.totalMemoryBytes - budget.deviceHeadroomBytes)
   })
 
   it("uses NVIDIA VRAM and Vulkan on Linux", async () => {
     const hardware = await detectHardware({
       env: { platform: "linux", arch: "x64", totalMemoryBytes: 32 * 1024 ** 3 },
-      nvidiaSmi: async () => "24576, 20480\n8192, 4096\n",
+      nvidiaSmi: async () => "24576\n8192\n",
     })
     expect(hardware.backend).toBe("vulkan")
     expect(hardware.gpuMemoryBytes).toBe((24576 + 8192) * 1024 * 1024)
-    expect(hardware.gpuMemoryFreeBytes).toBe((20480 + 4096) * 1024 * 1024)
-    expect(hardware.gpuDeviceCount).toBe(2)
     expect(hardware.unifiedMemory).toBe(false)
-    expect(availableInferenceMemory(hardware)).toBe((24576 + 8192 - 2048) * 1024 * 1024)
-    expect(currentlyAvailableInferenceMemory(hardware)).toBe((20480 + 4096 - 2048) * 1024 * 1024)
+    expect(availableModelMemory(hardware)).toBe(32 * 1024 ** 3 - 3_277 * 1024 ** 2)
   })
 
-  it("does not treat host RAM as available VRAM on discrete GPUs", () => {
+  it("uses host RAM for model capacity while preserving a separate VRAM budget", () => {
     const hardware = {
       platform: "linux" as const,
       arch: "x64",
       totalMemoryBytes: 32 * 1024 ** 3,
       gpuMemoryBytes: 8 * 1024 ** 3,
-      gpuMemoryFreeBytes: 3 * 1024 ** 3,
       backend: "vulkan" as const,
       unifiedMemory: false,
     }
-    expect(availableInferenceMemory(hardware)).toBe(7 * 1024 ** 3)
-    expect(currentlyAvailableInferenceMemory(hardware)).toBe(2 * 1024 ** 3)
+    expect(inferenceMemoryBudget(hardware).deviceHeadroomBytes).toBe(1024 ** 3)
+    expect(availableModelMemory(hardware)).toBe(32 * 1024 ** 3 - 3_277 * 1024 ** 2)
   })
 
   it("keeps one GiB of headroom on a 32 GB discrete GPU", () => {
@@ -56,17 +47,33 @@ describe("hardware detection", () => {
       arch: "x64",
       totalMemoryBytes: 64 * 1024 ** 3,
       gpuMemoryBytes: 32 * 1024 ** 3,
-      gpuMemoryFreeBytes: 32 * 1024 ** 3,
-      gpuDeviceCount: 1,
       backend: "vulkan" as const,
       unifiedMemory: false,
     }
 
-    expect(inferenceMemoryBudget(hardware)).toEqual({
-      availableBytes: 31 * 1024 ** 3,
-      deviceHeadroomBytes: 1024 ** 3,
+    expect(inferenceMemoryBudget(hardware)).toEqual({ deviceHeadroomBytes: 1024 ** 3 })
+  })
+
+  it("uses Vulkan for a vendor-neutral Linux render device", async () => {
+    const hardware = await detectHardware({
+      env: { platform: "linux", arch: "x64", totalMemoryBytes: 64 * 1024 ** 3 },
+      nvidiaSmi: async () => undefined,
+      linuxGraphics: async () => [{ memoryTotalBytes: 16 * 1024 ** 3 }],
     })
-    expect(currentlyAvailableInferenceMemory(hardware)).toBe(31 * 1024 ** 3)
+
+    expect(hardware).toMatchObject({ backend: "vulkan", gpuMemoryBytes: 16 * 1024 ** 3 })
+  })
+
+  it("uses Vulkan when a Linux render device does not report dedicated memory", async () => {
+    const hardware = await detectHardware({
+      env: { platform: "linux", arch: "arm64", totalMemoryBytes: 32 * 1024 ** 3 },
+      nvidiaSmi: async () => undefined,
+      linuxGraphics: async () => [{}],
+    })
+
+    expect(hardware).toMatchObject({ backend: "vulkan" })
+    expect(hardware.gpuMemoryBytes).toBeUndefined()
+    expect(inferenceMemoryBudget(hardware).deviceHeadroomBytes).toBe(3_277 * 1024 ** 2)
   })
 
   it("falls back to CPU when no GPU is reported", async () => {
@@ -75,6 +82,7 @@ describe("hardware detection", () => {
       nvidiaSmi: async () => {
         throw new Error("missing")
       },
+      linuxGraphics: async () => [],
     })
     expect(hardware).toMatchObject({ backend: "cpu", unifiedMemory: false })
     expect(hardware.gpuMemoryBytes).toBeUndefined()

--- a/tests/inference/llama-binary.test.ts
+++ b/tests/inference/llama-binary.test.ts
@@ -1,36 +1,29 @@
 import { describe, expect, it } from "vitest"
-import { assetNameFor, latestLlamaCppRelease, selectLlamaCppAsset } from "../../src/inference/llama-binary.js"
-
-const release = {
-  tag_name: "b10622",
-  assets: [
-    { name: "llama-b10622-bin-macos-arm64.tar.gz", browser_download_url: "https://example.test/mac", size: 10 },
-    { name: "llama-b10622-bin-ubuntu-vulkan-x64.tar.gz", browser_download_url: "https://example.test/vk", size: 11 },
-    { name: "llama-b10622-bin-ubuntu-x64.tar.gz", browser_download_url: "https://example.test/cpu", size: 12 },
-  ],
-}
+import { LLAMA_CPP_RELEASE_TAG, pinnedLlamaCppAsset, supportsLlamaCppTarget } from "../../src/inference/llama-binary.js"
 
 describe("llama.cpp binary selection", () => {
-  it("picks Metal, Vulkan, and CPU archives for the supported targets", () => {
-    expect(assetNameFor("b10622", { platform: "darwin", arch: "arm64", backend: "metal" })).toBe(
-      "llama-b10622-bin-macos-arm64.tar.gz",
-    )
-    expect(selectLlamaCppAsset(release, { platform: "linux", arch: "x64", backend: "vulkan" }).name).toBe(
+  it("builds deterministic asset URLs for the pinned release", () => {
+    expect(LLAMA_CPP_RELEASE_TAG).toBe("b10622")
+    expect(pinnedLlamaCppAsset({ platform: "darwin", arch: "arm64", backend: "metal" })).toEqual({
+      name: "llama-b10622-bin-macos-arm64.tar.gz",
+      url: "https://github.com/ggml-org/llama.cpp/releases/download/b10622/llama-b10622-bin-macos-arm64.tar.gz",
+      size: 10_954_906,
+      sha256: "c0116ec9957477a9c77e68d3cf31e79f9aede1a9210861c7c09d74acc3e9c3cf",
+    })
+    expect(pinnedLlamaCppAsset({ platform: "linux", arch: "x64", backend: "vulkan" }).name).toBe(
       "llama-b10622-bin-ubuntu-vulkan-x64.tar.gz",
     )
-    expect(selectLlamaCppAsset(release, { platform: "linux", arch: "x64", backend: "cpu" }).name).toBe(
+    expect(pinnedLlamaCppAsset({ platform: "linux", arch: "x64", backend: "cpu" }).name).toBe(
       "llama-b10622-bin-ubuntu-x64.tar.gz",
     )
   })
 
-  it("uses the newest b-release that actually has assets", () => {
-    const chosen = latestLlamaCppRelease([
-      {
-        tag_name: "v0.3.0",
-        assets: [{ name: "nightly-tag.txt", browser_download_url: "https://example.test/n", size: 1 }],
-      },
-      release,
-    ])
-    expect(chosen.tag_name).toBe("b10622")
+  it("rejects unsupported platforms before a model is selected", () => {
+    expect(supportsLlamaCppTarget({ platform: "linux", arch: "x64" })).toBe(true)
+    expect(supportsLlamaCppTarget({ platform: "darwin", arch: "arm64" })).toBe(true)
+    expect(supportsLlamaCppTarget({ platform: "win32", arch: "x64" })).toBe(false)
+    expect(() => pinnedLlamaCppAsset({ platform: "win32", arch: "x64", backend: "cpu" })).toThrow(
+      "Local inference is not supported on win32/x64.",
+    )
   })
 })

--- a/tests/inference/llama-runtime.test.ts
+++ b/tests/inference/llama-runtime.test.ts
@@ -1,5 +1,6 @@
+import { createHash } from "node:crypto"
 import { EventEmitter } from "node:events"
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, truncate, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -18,6 +19,16 @@ const hardware: HardwareProbe = {
   unifiedMemory: true,
 }
 
+const pinnedArchiveURL =
+  "https://github.com/ggml-org/llama.cpp/releases/download/b10622/llama-b10622-bin-macos-arm64.tar.gz"
+const archiveBody = Buffer.from("archive")
+const fakeRuntimeAsset: NonNullable<LlamaCppRuntimeOptions["runtimeAsset"]> = () => ({
+  name: "llama-b10622-bin-macos-arm64.tar.gz",
+  url: pinnedArchiveURL,
+  size: archiveBody.byteLength,
+  sha256: createHash("sha256").update(archiveBody).digest("hex"),
+})
+
 const tempDirectories: string[] = []
 
 afterEach(async () => {
@@ -33,6 +44,7 @@ describe("llama.cpp runtime", () => {
     const commands: string[] = []
     const runtime = new LlamaCppRuntime({
       env: {},
+      runtimeAsset: fakeRuntimeAsset,
       dataDirectory: directory,
       allocatePort: async () => 18764,
       spawn: ((command) => {
@@ -41,21 +53,7 @@ describe("llama.cpp runtime", () => {
       }) as LlamaCppRuntimeOptions["spawn"],
       fetch: (async (input: RequestInfo | URL) => {
         const url = String(input)
-        if (url.includes("api.github.com")) {
-          return Response.json([
-            {
-              tag_name: "b10622",
-              assets: [
-                {
-                  name: "llama-b10622-bin-macos-arm64.tar.gz",
-                  browser_download_url: "https://example.test/llama.tar.gz",
-                  size: 4,
-                },
-              ],
-            },
-          ])
-        }
-        if (url === "https://example.test/llama.tar.gz") return new Response("archive")
+        if (url === pinnedArchiveURL) return new Response(archiveBody)
         if (url.includes("/health")) return new Response("ok")
         if (url.includes("/props")) return runtimeProperties(fit.contextLength)
         return new Response("missing", { status: 404 })
@@ -75,22 +73,25 @@ describe("llama.cpp runtime", () => {
     const binary = commands[0]
     expect(binary).toBe(join(directory, "bin", "b10622", "llama-server"))
     expect(await readFile(join(dirname(binary as string), "libllama.dylib"), "utf8")).toBe("llama library")
-    expect(await readFile(join(dirname(binary as string), ".otis-runtime.json"), "utf8")).toContain('"backend":"metal"')
+    await expect(readFile(join(dirname(binary as string), ".otis-runtime.json"), "utf8")).resolves.toContain(
+      `"artifactSha256":"${fakeRuntimeAsset(hardware).sha256}"`,
+    )
     expect(await readFile(join(dirname(binary as string), "ggml-metal.metal"), "utf8")).toBe("metal backend")
     await runtime.stop()
   })
 
-  it("uses the newest cached llama.cpp release without querying GitHub", async () => {
+  it("uses only the pinned cached llama.cpp release without querying GitHub", async () => {
     const model = catalogModel()
     const fit = fitLocalModel(model, hardware)
     const directory = await tempDir()
     await cacheWeights(model, directory)
-    await installFakeBinary(directory, "b9999")
-    const newest = await installFakeBinary(directory, "b10622")
+    await installFakeBinary(directory, "b10623")
+    const pinned = await installFakeBinary(directory, "b10622")
     const urls: string[] = []
     let command = ""
     const runtime = new LlamaCppRuntime({
       env: {},
+      runtimeAsset: fakeRuntimeAsset,
       dataDirectory: directory,
       allocatePort: async () => 18763,
       spawn: ((nextCommand) => {
@@ -108,41 +109,39 @@ describe("llama.cpp runtime", () => {
 
     await runtime.ensureServing(model, fit, hardware)
 
-    expect(command).toBe(newest)
-    expect(urls.some((url) => url.includes("api.github.com"))).toBe(false)
+    expect(command).toBe(pinned)
+    expect(urls).not.toContain(pinnedArchiveURL)
+    await expect(stat(join(directory, "bin", "b10623"))).rejects.toMatchObject({ code: "ENOENT" })
     await runtime.stop()
   })
 
-  it("replaces a legacy cache containing only llama-server with a complete bundle", async () => {
+  it("replaces a cached bundle whose manifest does not match the pinned release", async () => {
     const model = catalogModel()
     const fit = fitLocalModel(model, hardware)
     const directory = await tempDir()
     await cacheWeights(model, directory)
-    const binary = await installLoneBinary(directory, "b10622")
+    const binary = await installFakeBinary(directory, "b10622")
+    await writeFile(
+      join(dirname(binary), ".otis-runtime.json"),
+      JSON.stringify({
+        version: 1,
+        releaseTag: "b10621",
+        platform: hardware.platform,
+        arch: hardware.arch,
+        backend: hardware.backend,
+      }),
+    )
     const urls: string[] = []
     const runtime = new LlamaCppRuntime({
       env: {},
+      runtimeAsset: fakeRuntimeAsset,
       dataDirectory: directory,
-      allocatePort: async () => 18762,
+      allocatePort: async () => 18760,
       spawn: ((_command, _args) => fakeChild()) as LlamaCppRuntimeOptions["spawn"],
       fetch: (async (input: RequestInfo | URL) => {
         const url = String(input)
         urls.push(url)
-        if (url.includes("api.github.com")) {
-          return Response.json([
-            {
-              tag_name: "b10622",
-              assets: [
-                {
-                  name: "llama-b10622-bin-macos-arm64.tar.gz",
-                  browser_download_url: "https://example.test/llama.tar.gz",
-                  size: 4,
-                },
-              ],
-            },
-          ])
-        }
-        if (url === "https://example.test/llama.tar.gz") return new Response("archive")
+        if (url === pinnedArchiveURL) return new Response(archiveBody)
         if (url.includes("/health")) return new Response("ok")
         if (url.includes("/props")) return runtimeProperties(fit.contextLength)
         return new Response("missing", { status: 404 })
@@ -158,21 +157,59 @@ describe("llama.cpp runtime", () => {
 
     await runtime.ensureServing(model, fit, hardware)
 
-    expect(urls.some((url) => url.includes("api.github.com"))).toBe(true)
+    expect(urls).toContain(pinnedArchiveURL)
+    expect(await readFile(binary, "utf8")).toBe("replacement server")
+    await runtime.stop()
+  })
+
+  it("replaces a legacy cache containing only llama-server with a complete bundle", async () => {
+    const model = catalogModel()
+    const fit = fitLocalModel(model, hardware)
+    const directory = await tempDir()
+    await cacheWeights(model, directory)
+    const binary = await installLoneBinary(directory, "b10622")
+    const urls: string[] = []
+    const runtime = new LlamaCppRuntime({
+      env: {},
+      runtimeAsset: fakeRuntimeAsset,
+      dataDirectory: directory,
+      allocatePort: async () => 18762,
+      spawn: ((_command, _args) => fakeChild()) as LlamaCppRuntimeOptions["spawn"],
+      fetch: (async (input: RequestInfo | URL) => {
+        const url = String(input)
+        urls.push(url)
+        if (url === pinnedArchiveURL) return new Response(archiveBody)
+        if (url.includes("/health")) return new Response("ok")
+        if (url.includes("/props")) return runtimeProperties(fit.contextLength)
+        return new Response("missing", { status: 404 })
+      }) as typeof fetch,
+      extractArchive: async (_archive, destination) => {
+        const bundle = join(destination, "bin")
+        await mkdir(bundle, { recursive: true })
+        await writeFile(join(bundle, "llama-server"), "replacement server")
+        await writeFile(join(bundle, "libllama.dylib"), "llama library")
+        await writeFile(join(bundle, "libggml.dylib"), "ggml library")
+      },
+    })
+
+    await runtime.ensureServing(model, fit, hardware)
+
+    expect(urls).toContain(pinnedArchiveURL)
     expect(await readFile(binary, "utf8")).toBe("replacement server")
     expect(await readFile(join(dirname(binary), "libllama.dylib"), "utf8")).toBe("llama library")
     await runtime.stop()
   })
 
   it("downloads the GGUF then starts llama-server with a local model path", async () => {
-    const model = findLocalModel("openai/gpt-oss-20b")
-    if (!model) throw new Error("missing catalog entry")
-    const fit = fitLocalModel(model, hardware)
+    const catalog = findLocalModel("openai/gpt-oss-20b")
+    if (!catalog) throw new Error("missing catalog entry")
     const spawned: string[][] = []
     const progress: Array<{ phase: string; percent?: number }> = []
     const child = fakeChild()
     const directory = await tempDir()
     const weights = new Uint8Array([1, 2, 3, 4])
+    const model = tinyModel(catalog, weights)
+    const fit = fitLocalModel(model, hardware)
     const fittedContext = 32_768
     const runtime = new LlamaCppRuntime({
       env: { OTIS_LLAMA_SERVER: process.execPath },
@@ -212,7 +249,9 @@ describe("llama.cpp runtime", () => {
     )
     expect(spawned[0]).not.toContain("--ctx-size")
     expect(spawned[0]).not.toContain("--n-gpu-layers")
-    expect((await runtime.ensureServing(model, fit, hardware)).contextLength).toBe(fittedContext)
+    expect((await runtime.ensureServing(model, { ...fit, contextLength: fittedContext }, hardware)).contextLength).toBe(
+      fittedContext,
+    )
     expect(spawned).toHaveLength(1)
     expect(progress).toEqual(expect.arrayContaining([{ phase: "download", percent: 100 }, { phase: "loading" }]))
     await runtime.stop()
@@ -256,8 +295,7 @@ describe("llama.cpp runtime", () => {
     if (!model) throw new Error("missing catalog entry")
     const fit = fitLocalModel(model, hardware)
     const directory = await tempDir()
-    await mkdir(join(directory, "models"), { recursive: true })
-    await writeFile(localGgufPath(model, directory), "cached-weights")
+    await cacheWeights(model, directory)
     const urls: string[] = []
     const runtime = new LlamaCppRuntime({
       env: { OTIS_LLAMA_SERVER: process.execPath },
@@ -284,8 +322,7 @@ describe("llama.cpp runtime", () => {
     if (!model) throw new Error("missing catalog entry")
     const fit = fitLocalModel(model, hardware)
     const directory = await tempDir()
-    await mkdir(join(directory, "models"), { recursive: true })
-    await writeFile(localGgufPath(model, directory), "cached-weights")
+    await cacheWeights(model, directory)
     const child = fakeChild()
     child.kill = () => {
       queueMicrotask(() => {
@@ -371,6 +408,120 @@ describe("llama.cpp runtime", () => {
     const runtime = new LlamaCppRuntime({ env: { OTIS_LLAMA_SERVER: process.execPath } })
     await expect(runtime.ensureServing(model, fitLocalModel(model, tight), tight)).rejects.toThrow("needs")
   })
+
+  it("rejects unsupported platforms before resolving or spawning a runtime", async () => {
+    const model = catalogModel()
+    const unsupported: HardwareProbe = {
+      ...hardware,
+      platform: "win32",
+      arch: "x64",
+      backend: "cpu",
+      unifiedMemory: false,
+    }
+    const spawnRuntime = vi.fn()
+    const runtime = new LlamaCppRuntime({
+      env: { OTIS_LLAMA_SERVER: process.execPath },
+      spawn: spawnRuntime as unknown as LlamaCppRuntimeOptions["spawn"],
+    })
+
+    await expect(runtime.ensureServing(model, fitLocalModel(model, unsupported), unsupported)).rejects.toThrow(
+      "Local inference is not supported on win32/x64.",
+    )
+    expect(spawnRuntime).not.toHaveBeenCalled()
+  })
+
+  it("does not spawn a superseded start after asynchronous port allocation", async () => {
+    const firstModel = catalogModel()
+    const secondModel = findLocalModel("Qwen/Qwen3.8-27B")
+    if (!secondModel) throw new Error("missing catalog entry")
+    const directory = await tempDir()
+    await cacheWeights(firstModel, directory)
+    await cacheWeights(secondModel, directory)
+    let releaseFirstPort: ((port: number) => void) | undefined
+    let firstPortStarted: (() => void) | undefined
+    const portStarted = new Promise<void>((resolve) => {
+      firstPortStarted = resolve
+    })
+    let allocation = 0
+    const spawnRuntime = vi.fn(() => fakeChild())
+    const runtime = new LlamaCppRuntime({
+      env: { OTIS_LLAMA_SERVER: process.execPath },
+      dataDirectory: directory,
+      allocatePort: async () => {
+        allocation += 1
+        if (allocation > 1) return 18771
+        firstPortStarted?.()
+        return await new Promise<number>((resolve) => {
+          releaseFirstPort = resolve
+        })
+      },
+      spawn: spawnRuntime as unknown as LlamaCppRuntimeOptions["spawn"],
+      fetch: (async (input: RequestInfo | URL) => {
+        if (String(input).includes("/props")) return runtimeProperties(32_768)
+        return new Response("ok")
+      }) as typeof fetch,
+    })
+
+    const first = runtime.ensureServing(firstModel, fitLocalModel(firstModel, hardware), hardware)
+    await portStarted
+    const second = runtime.ensureServing(secondModel, fitLocalModel(secondModel, hardware), hardware)
+    await second
+    releaseFirstPort?.(18770)
+
+    await expect(first).rejects.toMatchObject({ name: "AbortError" })
+    expect(spawnRuntime).toHaveBeenCalledTimes(1)
+    expect(runtime.serving?.model).toBe(secondModel.id)
+    await runtime.stop()
+  })
+
+  it("keeps the final 20 KB of startup logs across chunk boundaries", async () => {
+    const model = catalogModel()
+    const directory = await tempDir()
+    await cacheWeights(model, directory)
+    const child = fakeChild()
+    let emitted = false
+    const runtime = new LlamaCppRuntime({
+      env: { OTIS_LLAMA_SERVER: process.execPath },
+      dataDirectory: directory,
+      allocatePort: async () => 18772,
+      spawn: (() => child) as unknown as LlamaCppRuntimeOptions["spawn"],
+      fetch: (async () => new Response("loading", { status: 503 })) as typeof fetch,
+      sleep: async () => {
+        if (emitted) return
+        emitted = true
+        child.stderr.emit("data", `${"x".repeat(14_000)}FIRST-TAIL`)
+        child.stderr.emit("data", "y".repeat(5_000))
+        child.stderr.emit("data", `${"z".repeat(5_000)}FINAL`)
+        child.exitCode = 1
+      },
+    })
+
+    await expect(runtime.ensureServing(model, fitLocalModel(model, hardware), hardware)).rejects.toThrow(
+      /FIRST-TAIL[\s\S]*FINAL/,
+    )
+  })
+
+  it("rejects a llama.cpp archive whose checksum does not match the pin", async () => {
+    const model = catalogModel()
+    const directory = await tempDir()
+    await cacheWeights(model, directory)
+    const spawnRuntime = vi.fn()
+    const extractArchive = vi.fn()
+    const runtime = new LlamaCppRuntime({
+      env: {},
+      dataDirectory: directory,
+      runtimeAsset: () => ({ ...fakeRuntimeAsset(hardware), sha256: "0".repeat(64) }),
+      spawn: spawnRuntime as LlamaCppRuntimeOptions["spawn"],
+      extractArchive,
+      fetch: (async () => new Response(archiveBody)) as typeof fetch,
+    })
+
+    await expect(runtime.ensureServing(model, fitLocalModel(model, hardware), hardware)).rejects.toThrow(
+      "SHA-256 verification failed",
+    )
+    expect(extractArchive).not.toHaveBeenCalled()
+    expect(spawnRuntime).not.toHaveBeenCalled()
+  })
 })
 
 async function tempDir() {
@@ -407,7 +558,27 @@ function catalogModel() {
 
 async function cacheWeights(model: ReturnType<typeof catalogModel>, directory: string) {
   await mkdir(join(directory, "models"), { recursive: true })
-  await writeFile(localGgufPath(model, directory), "cached-weights")
+  const path = localGgufPath(model, directory)
+  await writeFile(path, "")
+  await truncate(path, model.weightBytes)
+  await writeFile(
+    `${path}.otis.json`,
+    JSON.stringify({
+      version: 1,
+      model: model.id,
+      revision: model.ggufRevision,
+      sha256: model.ggufSha256,
+      size: model.weightBytes,
+    }),
+  )
+}
+
+function tinyModel(model: ReturnType<typeof catalogModel>, contents: Uint8Array) {
+  return {
+    ...model,
+    weightBytes: contents.byteLength,
+    ggufSha256: createHash("sha256").update(contents).digest("hex"),
+  }
 }
 
 async function installFakeBinary(directory: string, release: string) {

--- a/tests/inference/picker-catalog.test.ts
+++ b/tests/inference/picker-catalog.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, truncate, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
@@ -34,7 +34,7 @@ afterEach(async () => {
 })
 
 describe("model picker catalog", () => {
-  it("lists official local models above Fireworks entries", async () => {
+  it("lists official local models above hosted entries", async () => {
     const items = await listModelPickerItems({
       hardware: ample,
       dataDirectory: await tempDir(),
@@ -49,9 +49,9 @@ describe("model picker catalog", () => {
     expect(items.slice(1, 1 + LOCAL_MODELS.length).map((item) => ("id" in item ? item.id : undefined))).toEqual(
       LOCAL_MODELS.map((model) => model.id),
     )
-    const fireworksHeader = items.findIndex((item) => item.kind === "header" && item.displayName === "Fireworks")
-    expect(fireworksHeader).toBe(1 + LOCAL_MODELS.length)
-    expect(items[fireworksHeader + 1]).toMatchObject({
+    const hostedHeader = items.findIndex((item) => item.kind === "header" && item.displayName === "Hosted")
+    expect(hostedHeader).toBe(1 + LOCAL_MODELS.length)
+    expect(items[hostedHeader + 1]).toMatchObject({
       id: "accounts/fireworks/models/inkling",
       provider: "fireworks",
       active: true,
@@ -68,36 +68,34 @@ describe("model picker catalog", () => {
     expect(local.every((item) => item.downloaded === false)).toBe(true)
   })
 
-  it("uses free VRAM for recommendations without turning current GPU pressure into a hard limit", async () => {
-    const busyGpu: HardwareProbe = {
+  it("keeps hybrid-offload models available when system RAM is sufficient", async () => {
+    const smallGpu: HardwareProbe = {
       platform: "linux",
       arch: "x64",
       totalMemoryBytes: 64 * 1024 ** 3,
-      gpuMemoryBytes: 32 * 1024 ** 3,
-      gpuMemoryFreeBytes: 24 * 1024 ** 3,
+      gpuMemoryBytes: 8 * 1024 ** 3,
       backend: "vulkan",
       unifiedMemory: false,
     }
     const directory = await tempDir()
-    const items = await listModelPickerItems({ hardware: busyGpu, dataDirectory: directory })
-    const qwen = items.find(
-      (item): item is LocalPickerChoice =>
-        item.kind === "model" && item.provider === "local" && item.id === "Qwen/Qwen3.8-27B",
-    )
+    const items = await listModelPickerItems({ hardware: smallGpu, dataDirectory: directory })
+    const local = items.filter((item): item is LocalPickerChoice => item.kind === "model" && item.provider === "local")
 
-    expect(qwen).toMatchObject({ available: true })
-    expect(qwen?.availabilityLabel).not.toContain("VRAM free")
+    expect(local.every((item) => item.available)).toBe(true)
+    expect(local.every((item) => item.availabilityLabel.startsWith("Est. "))).toBe(true)
+  })
 
-    const idleItems = await listModelPickerItems({
-      hardware: { ...busyGpu, gpuMemoryFreeBytes: busyGpu.gpuMemoryBytes },
-      dataDirectory: directory,
+  it("greys out local models on unsupported platforms before selection", async () => {
+    const items = await listModelPickerItems({
+      hardware: { ...ample, platform: "win32", arch: "x64", backend: "cpu", unifiedMemory: false },
+      dataDirectory: await tempDir(),
     })
-    const idleQwen = idleItems.find(
-      (item): item is LocalPickerChoice =>
-        item.kind === "model" && item.provider === "local" && item.id === "Qwen/Qwen3.8-27B",
+    const local = items.filter((item): item is LocalPickerChoice => item.kind === "model" && item.provider === "local")
+
+    expect(local.every((item) => !item.available)).toBe(true)
+    expect(local.every((item) => item.availabilityLabel === "Local inference is not supported on win32/x64.")).toBe(
+      true,
     )
-    expect(qwen?.contextLength).toBeLessThan(idleQwen?.contextLength ?? 0)
-    expect(qwen?.availabilityLabel).toMatch(/^Up to /)
   })
 
   it("marks local models that are already on disk", async () => {
@@ -105,7 +103,8 @@ describe("model picker catalog", () => {
     const cached = LOCAL_MODELS.find((model) => model.id === "openai/gpt-oss-20b")
     if (!cached) throw new Error("missing catalog entry")
     await mkdir(join(directory, "models"), { recursive: true })
-    await writeFile(localGgufPath(cached, directory), "cached")
+    await writeFile(localGgufPath(cached, directory), "")
+    await truncate(localGgufPath(cached, directory), cached.weightBytes)
 
     const items = await listModelPickerItems({ hardware: ample, dataDirectory: directory })
     const local = items.filter((item): item is LocalPickerChoice => item.kind === "model" && item.provider === "local")
@@ -133,7 +132,7 @@ describe("model picker catalog", () => {
     })
     expect(active?.availabilityLabel).toMatch(/^80K loaded · Q4_K_M · /)
     expect(
-      local.filter((item) => item.id !== model.id).every((item) => item.availabilityLabel.startsWith("Up to ")),
+      local.filter((item) => item.id !== model.id).every((item) => item.availabilityLabel.startsWith("Est. ")),
     ).toBe(true)
   })
 
@@ -141,13 +140,19 @@ describe("model picker catalog", () => {
     const items = await listModelPickerItems({
       hardware: ample,
       dataDirectory: await tempDir(),
-      loadStatus: { modelId: "openai/gpt-oss-20b", label: "47%" },
+      loadStatus: {
+        modelId: "openai/gpt-oss-20b",
+        status: { label: "Downloading 47%", kind: "progress" },
+      },
     })
     const local = items.filter((item): item is LocalPickerChoice => item.kind === "model" && item.provider === "local")
-    expect(local.find((item) => item.id === "openai/gpt-oss-20b")?.statusLabel).toBe("47%")
-    expect(
-      local.filter((item) => item.id !== "openai/gpt-oss-20b").every((item) => item.statusLabel === undefined),
-    ).toBe(true)
+    expect(local.find((item) => item.id === "openai/gpt-oss-20b")?.status).toEqual({
+      label: "Downloading 47%",
+      kind: "progress",
+    })
+    expect(local.filter((item) => item.id !== "openai/gpt-oss-20b").every((item) => item.status === undefined)).toBe(
+      true,
+    )
   })
 
   it("still shows local models when the Fireworks catalog fails", async () => {
@@ -159,7 +164,7 @@ describe("model picker catalog", () => {
         throw new Error("Fireworks down")
       },
     })
-    expect(items.some((item) => item.kind === "header" && item.displayName === "Fireworks")).toBe(false)
+    expect(items.some((item) => item.kind === "header" && item.displayName === "Hosted")).toBe(false)
     expect(items.some((item) => item.kind !== "header" && item.id === "openai/gpt-oss-20b")).toBe(true)
   })
 
@@ -173,11 +178,11 @@ describe("model picker catalog", () => {
     const items = await listModelPickerItems({ hardware: ample, dataDirectory: await tempDir() })
     const local = items.filter((item): item is LocalPickerChoice => item.kind === "model" && item.provider === "local")
     expect(local.map((item) => item.availabilityLabel.split(" ·")[0])).toEqual([
-      "Up to 256K",
-      "Up to 256K",
-      "Up to 128K",
-      "Up to 256K",
-      "Up to 256K",
+      "Est. 256K",
+      "Est. 256K",
+      "Est. 128K",
+      "Est. 256K",
+      "Est. 256K",
     ])
   })
 })

--- a/tests/inference/serving-path.test.ts
+++ b/tests/inference/serving-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  baseFireworksModelId,
   baseModelIdForFastServingPath,
   fireworksServiceTier,
   fireworksServingModel,
@@ -25,6 +26,8 @@ describe("Fireworks serving paths", () => {
       "accounts/fireworks/models/kimi-k2p7-code",
     )
     expect(baseModelIdForFastServingPath("accounts/fireworks/models/kimi-k3")).toBeUndefined()
+    expect(baseFireworksModelId("accounts/fireworks/routers/kimi-k3-fast")).toBe("accounts/fireworks/models/kimi-k3")
+    expect(baseFireworksModelId("accounts/fireworks/models/kimi-k3")).toBe("accounts/fireworks/models/kimi-k3")
   })
 
   it("omits Priority on Fast requests and keeps it for base models", () => {

--- a/tests/local/settings.test.ts
+++ b/tests/local/settings.test.ts
@@ -5,7 +5,8 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   clearSelectedModel,
   loadLocalSettings,
-  saveFastMode,
+  saveFastServingSelection,
+  saveFireworksApiKey,
   saveFireworksSetup,
   saveSelectedModel,
   saveSelectedTheme,
@@ -19,6 +20,29 @@ afterEach(async () => {
 })
 
 describe("local settings", () => {
+  it("stores a Fireworks key without replacing the selected local model", async () => {
+    const file = join(await tempDirectory(), "config", "config.json")
+    await saveSelectedModel(
+      {
+        provider: "local",
+        id: "openai/gpt-oss-20b",
+        displayName: "gpt-oss 20B",
+        contextLength: 32_768,
+        supportsImageInput: false,
+      },
+      { file },
+    )
+
+    await saveFireworksApiKey(" fw_test_key ", { file })
+
+    await expect(loadLocalSettings({ file, env: {} })).resolves.toMatchObject({
+      fireworksApiKey: "fw_test_key",
+      model: "openai/gpt-oss-20b",
+      modelProvider: "local",
+      modelContextLength: 32_768,
+    })
+  })
+
   it("stores the Fireworks key and selected model in a private local file", async () => {
     const file = join(await tempDirectory(), "config", "config.json")
     await saveFireworksSetup(" fw_test_key ", model("tool-model", "Tool Model", 131_072), { file })
@@ -88,7 +112,7 @@ describe("local settings", () => {
     await saveFireworksSetup("fw_test_key", model("tool-model", "Tool Model", 32_768), { file })
     await saveSelectedTheme("nord", { file })
     await saveThinkingVisible(true, { file })
-    await saveFastMode(false, { file })
+    await saveFastServingSelection(model("tool-model", "Tool Model"), false, { file })
 
     await clearSelectedModel({ file })
 
@@ -97,7 +121,7 @@ describe("local settings", () => {
       fireworksApiKey: "fw_test_key",
       theme: "nord",
       thinkingVisible: true,
-      fastMode: false,
+      fastServingModels: [],
     })
   })
 
@@ -147,16 +171,49 @@ describe("local settings", () => {
     expect(JSON.parse(await readFile(file, "utf8"))).not.toHaveProperty("modelFastId")
   })
 
-  it("stores Fast serving preference independently from the selected model", async () => {
+  it("stores Fast serving preferences per model", async () => {
     const file = join(await tempDirectory(), "config.json")
-    await saveFireworksSetup("fw_test_key", model("tool-model", "Tool Model"), { file })
-    await saveFastMode(false, { file })
+    const alpha = fastModel("alpha", "Alpha")
+    const beta = fastModel("beta", "Beta")
+    await saveFireworksSetup("fw_test_key", alpha, { file })
+    await saveFastServingSelection({ ...alpha, id: alpha.fastId }, true, { file })
+    await saveFastServingSelection({ ...beta, id: beta.fastId }, true, { file })
+    await saveFastServingSelection(alpha, false, { file })
 
-    await expect(loadLocalSettings({ file, env: {} })).resolves.toMatchObject({ fastMode: false })
+    await expect(loadLocalSettings({ file, env: {} })).resolves.toMatchObject({
+      model: alpha.id,
+      fastServingModels: [beta.id],
+    })
     expect(JSON.parse(await readFile(file, "utf8"))).toMatchObject({
       fireworksApiKey: "fw_test_key",
-      fastMode: false,
+      model: alpha.id,
+      fastServingModels: [beta.id],
     })
+  })
+
+  it("migrates the released global Fast preference to the selected model", async () => {
+    const file = join(await tempDirectory(), "config.json")
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        model: "accounts/fireworks/models/alpha",
+        modelProvider: "fireworks",
+        fastMode: true,
+      }),
+      "utf8",
+    )
+
+    await expect(loadLocalSettings({ file, env: {} })).resolves.toMatchObject({
+      fastServingModels: ["accounts/fireworks/models/alpha"],
+    })
+
+    await saveSelectedModel(model("beta", "Beta"), { file })
+    expect(JSON.parse(await readFile(file, "utf8"))).toMatchObject({
+      model: "accounts/fireworks/models/beta",
+      fastServingModels: ["accounts/fireworks/models/alpha"],
+    })
+    expect(JSON.parse(await readFile(file, "utf8"))).not.toHaveProperty("fastMode")
   })
 
   it("loads and preserves permission policy while changing other settings", async () => {
@@ -244,12 +301,14 @@ describe("local settings", () => {
     const invalidTheme = join(directory, "invalid-theme.json")
     const invalidThinking = join(directory, "invalid-thinking.json")
     const invalidFastMode = join(directory, "invalid-fast-mode.json")
+    const invalidFastServingModels = join(directory, "invalid-fast-serving-models.json")
     await writeFile(malformed, "{broken", "utf8")
     await writeFile(unsupported, JSON.stringify({ version: 2 }), "utf8")
     await writeFile(invalidMetadata, JSON.stringify({ version: 1, modelContextLength: -1 }), "utf8")
     await writeFile(invalidTheme, JSON.stringify({ version: 1, theme: "blue" }), "utf8")
     await writeFile(invalidThinking, JSON.stringify({ version: 1, thinkingVisible: "sometimes" }), "utf8")
     await writeFile(invalidFastMode, JSON.stringify({ version: 1, fastMode: "sometimes" }), "utf8")
+    await writeFile(invalidFastServingModels, JSON.stringify({ version: 1, fastServingModels: [false] }), "utf8")
 
     await expect(loadLocalSettings({ file: malformed, env: {} })).rejects.toThrow("Invalid Otis config")
     await expect(loadLocalSettings({ file: unsupported, env: {} })).rejects.toThrow("unsupported version")
@@ -257,6 +316,9 @@ describe("local settings", () => {
     await expect(loadLocalSettings({ file: invalidTheme, env: {} })).rejects.toThrow("theme must be")
     await expect(loadLocalSettings({ file: invalidThinking, env: {} })).rejects.toThrow("thinkingVisible must be")
     await expect(loadLocalSettings({ file: invalidFastMode, env: {} })).rejects.toThrow("fastMode must be")
+    await expect(loadLocalSettings({ file: invalidFastServingModels, env: {} })).rejects.toThrow(
+      "fastServingModels must be",
+    )
   })
 })
 
@@ -273,5 +335,12 @@ function model(name: string, displayName: string, contextLength?: number) {
     displayName,
     supportsImageInput: false,
     ...(contextLength ? { contextLength } : {}),
+  }
+}
+
+function fastModel(name: string, displayName: string) {
+  return {
+    ...model(name, displayName),
+    fastId: `accounts/fireworks/routers/${name}-fast`,
   }
 }


### PR DESCRIPTION
  - add hosted and local inference onboarding
  - manage pinned llama.cpp runtime and verified GGUF downloads
  - detect hardware and fit local models to available memory
  - add local model selection, deletion, and settings flows
  - persist fast mode per model
  - fix nested menu navigation and loading-state UI behavior